### PR TITLE
range.sql: drop redundant check for existing tables

### DIFF
--- a/range.sql
+++ b/range.sql
@@ -446,12 +446,6 @@ BEGIN
         EXIT WHEN v_child_relname_exists = 0;
     END LOOP;
 
-    /* Skip existing partitions */
-    IF EXISTS (SELECT * FROM pg_tables WHERE tablename = v_child_relname) THEN
-        RAISE WARNING 'Relation % already exists, skipping...', v_child_relname;
-        RETURN NULL;
-    END IF;
-
     EXECUTE format('CREATE TABLE %s (LIKE %s INCLUDING ALL)'
                    , v_child_relname
                    , p_parent);


### PR DESCRIPTION
The check is always false as v_child_relname is schema-qualified while the
comparison is to a plain table name.  The entire check can be removed
instead of fixing it as a few lines above we have a loop which comes up with
a unique name.