### PR TITLE
dot editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
For some reason github formats tabs as eight spaces, this messes up the formatting of sql files in pg_pathman.  For example compare:

https://github.com/postgrespro/pg_pathman/blob/master/range.sql

to:

https://github.com/michelp/pg_pathman/blob/master/range.sql

this PR drops an editorconfig file to improve formatting.