### PR TITLE
Use analyzed expression trees for constraint construction.

### DIFF
--- a/hash.sql
+++ b/hash.sql
@@ -108,7 +108,7 @@ BEGIN
 
 	/* Fetch definition of old_partition's HASH constraint */
 	SELECT pg_catalog.pg_get_constraintdef(oid) FROM pg_catalog.pg_constraint
-	WHERE conrelid = old_partition AND conname = old_constr_name
+	WHERE conrelid = old_partition AND quote_ident(conname) = old_constr_name
 	INTO old_constr_def;
 
 	/* Detach old partition */


### PR DESCRIPTION
Initially I planned this as an easy change which would
 * Allow to use weird types such as bytea as hash partitioning key --
   currently we can't do that because hashvarlena declared as accepting
   'internal' type, and analyzer can't pass bytea to it.
 * Make everything a bit simpler, because expression is analyzed anyway
   (cook_partitioning_expression), so a bit of code unification was expected.

Eventually it turned out to be much more cumbersome for various reasons (e.g.
analyzed trees should be adapted for childs due to dropped columns), so I am not
even sure it is worthwhile anymore.

Also, micro bug fix at partition_filter.c