### PR TITLE
Adapt pg_pathman for PG 11.

### DIFF
--- a/expected/pathman_expressions_1.out
+++ b/expected/pathman_expressions_1.out
@@ -166,38 +166,42 @@ SELECT *, tableoid::REGCLASS FROM test_exprs.composite;
 (3 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM test_exprs.composite WHERE (a, b)::test_exprs.composite < (21, 0)::test_exprs.composite;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Append
    ->  Seq Scan on composite_1
    ->  Seq Scan on composite_2
    ->  Seq Scan on composite_3
-         Filter: (ROW(a, b)::test_exprs.composite < '(21,0)'::test_exprs.composite)
+         Filter: (ROW(a, b)::test_exprs.composite < ROW(21, '0'::text)::test_exprs.composite)
 (5 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM test_exprs.composite WHERE (a, b) < (21, 0)::test_exprs.composite;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Append
    ->  Seq Scan on composite_1
-         Filter: (ROW(a, b) < '(21,0)'::test_exprs.composite)
+         Filter: (ROW(a, b) < ROW(21, '0'::text)::test_exprs.composite)
    ->  Seq Scan on composite_2
-         Filter: (ROW(a, b) < '(21,0)'::test_exprs.composite)
+         Filter: (ROW(a, b) < ROW(21, '0'::text)::test_exprs.composite)
    ->  Seq Scan on composite_3
-         Filter: (ROW(a, b) < '(21,0)'::test_exprs.composite)
+         Filter: (ROW(a, b) < ROW(21, '0'::text)::test_exprs.composite)
    ->  Seq Scan on composite_4
-         Filter: (ROW(a, b) < '(21,0)'::test_exprs.composite)
+         Filter: (ROW(a, b) < ROW(21, '0'::text)::test_exprs.composite)
 (9 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM test_exprs.composite WHERE (a, b)::test_exprs.composite < (21, 0);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Append
    ->  Seq Scan on composite_1
+         Filter: (ROW(a, b)::test_exprs.composite < ROW(21, 0))
    ->  Seq Scan on composite_2
+         Filter: (ROW(a, b)::test_exprs.composite < ROW(21, 0))
    ->  Seq Scan on composite_3
-         Filter: (ROW(a, b)::test_exprs.composite < '(21,0)'::record)
-(5 rows)
+         Filter: (ROW(a, b)::test_exprs.composite < ROW(21, 0))
+   ->  Seq Scan on composite_4
+         Filter: (ROW(a, b)::test_exprs.composite < ROW(21, 0))
+(9 rows)
 
 DROP TABLE test_exprs.composite CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/expected/pathman_permissions.out
+++ b/expected/pathman_permissions.out
@@ -12,15 +12,23 @@ CREATE TABLE permissions.user1_table(id serial, a int);
 INSERT INTO permissions.user1_table SELECT g, g FROM generate_series(1, 20) as g;
 /* Should fail (can't SELECT) */
 SET ROLE user2;
-SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
-ERROR:  permission denied for relation user1_table
+DO $$
+BEGIN
+    SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
+EXCEPTION
+    WHEN insufficient_privilege THEN
+END$$;
 /* Grant SELECT to user2 */
 SET ROLE user1;
 GRANT SELECT ON permissions.user1_table TO user2;
 /* Should fail (don't own parent) */
 SET ROLE user2;
-SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
-ERROR:  only the owner or superuser can change partitioning configuration of table "user1_table"
+DO $$
+BEGIN
+    SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
+EXCEPTION
+    WHEN insufficient_privilege THEN
+END$$;
 /* Should be ok */
 SET ROLE user1;
 SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
@@ -58,8 +66,12 @@ WHERE partrel = 'permissions.user1_table'::regclass;
 WARNING:  only the owner or superuser can change partitioning configuration of table "user1_table"
 /* No rights to insert, should fail */
 SET ROLE user2;
-INSERT INTO permissions.user1_table (id, a) VALUES (35, 0);
-ERROR:  permission denied for relation user1_table
+DO $$
+BEGIN
+    INSERT INTO permissions.user1_table (id, a) VALUES (35, 0);
+EXCEPTION
+    WHEN insufficient_privilege THEN
+END$$;
 /* No rights to create partitions (need INSERT privilege) */
 SET ROLE user2;
 SELECT prepend_range_partition('permissions.user1_table');
@@ -116,8 +128,12 @@ ORDER BY relname; /* we also check ACL for "user1_table_2" */
 (3 rows)
 
 /* Try to drop partition, should fail */
-SELECT drop_range_partition('permissions.user1_table_4');
-ERROR:  must be owner of relation user1_table_4
+DO $$
+BEGIN
+    SELECT drop_range_partition('permissions.user1_table_4');
+EXCEPTION
+    WHEN insufficient_privilege THEN
+END$$;
 /* Disable automatic partition creation */
 SET ROLE user1;
 SELECT set_auto('permissions.user1_table', false);

--- a/expected/pathman_permissions.out
+++ b/expected/pathman_permissions.out
@@ -17,7 +17,9 @@ BEGIN
     SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
+NOTICE:  Insufficient priviliges
 /* Grant SELECT to user2 */
 SET ROLE user1;
 GRANT SELECT ON permissions.user1_table TO user2;
@@ -28,7 +30,9 @@ BEGIN
     SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
+NOTICE:  Insufficient priviliges
 /* Should be ok */
 SET ROLE user1;
 SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
@@ -71,7 +75,9 @@ BEGIN
     INSERT INTO permissions.user1_table (id, a) VALUES (35, 0);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
+NOTICE:  Insufficient priviliges
 /* No rights to create partitions (need INSERT privilege) */
 SET ROLE user2;
 SELECT prepend_range_partition('permissions.user1_table');
@@ -133,7 +139,9 @@ BEGIN
     SELECT drop_range_partition('permissions.user1_table_4');
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
+NOTICE:  Insufficient priviliges
 /* Disable automatic partition creation */
 SET ROLE user1;
 SELECT set_auto('permissions.user1_table', false);

--- a/expected/pathman_rebuild_deletes.out
+++ b/expected/pathman_rebuild_deletes.out
@@ -1,3 +1,9 @@
+/*
+ * -------------------------------------------
+ *  NOTE: This test behaves differenly on < 11 because planner now turns
+ *  Row(Const, Const) into just Const of record type, apparently since 3decd150
+ * -------------------------------------------
+ */
 \set VERBOSITY terse
 SET search_path = 'public';
 CREATE EXTENSION pg_pathman;
@@ -86,11 +92,11 @@ RETURNING t1.*, t1.tableoid::REGCLASS;
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test
 WHERE val = 101 AND test >= (100, 8)
 RETURNING *, tableoid::REGCLASS;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Delete on test_11
    ->  Seq Scan on test_11
-         Filter: (((test_11.*)::test_deletes.test >= ROW(100, 8)) AND (val = 101))
+         Filter: (((test_11.*)::test_deletes.test >= '(100,8)'::record) AND (val = 101))
 (3 rows)
 
 DROP TABLE test_deletes.test_dummy;

--- a/expected/pathman_rebuild_deletes_1.out
+++ b/expected/pathman_rebuild_deletes_1.out
@@ -4,61 +4,102 @@
  *  Row(Const, Const) into just Const of record type, apparently since 3decd150
  * -------------------------------------------
  */
-
 \set VERBOSITY terse
-
 SET search_path = 'public';
 CREATE EXTENSION pg_pathman;
 CREATE SCHEMA test_deletes;
-
-
 /*
  * Test DELETEs on a partition with different TupleDescriptor.
  */
-
 /* create partitioned table */
 CREATE TABLE test_deletes.test(a FLOAT4, val INT4 NOT NULL, b FLOAT8);
 INSERT INTO test_deletes.test SELECT i, i, i FROM generate_series(1, 100) AS i;
 SELECT create_range_partitions('test_deletes.test', 'val', 1, 10);
+ create_range_partitions 
+-------------------------
+                      10
+(1 row)
 
 /* drop column 'a' */
 ALTER TABLE test_deletes.test DROP COLUMN a;
-
 /* append new partition */
 SELECT append_range_partition('test_deletes.test');
+ append_range_partition 
+------------------------
+ test_deletes.test_11
+(1 row)
+
 INSERT INTO test_deletes.test_11 (val, b) VALUES (101, 10);
-
-
 VACUUM ANALYZE;
-
-
 /* tuple descs are the same */
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test WHERE val = 1;
-DELETE FROM test_deletes.test WHERE val = 1 RETURNING *, tableoid::REGCLASS;
+        QUERY PLAN         
+---------------------------
+ Delete on test_1
+   ->  Seq Scan on test_1
+         Filter: (val = 1)
+(3 rows)
 
+DELETE FROM test_deletes.test WHERE val = 1 RETURNING *, tableoid::REGCLASS;
+ val | b |      tableoid       
+-----+---+---------------------
+   1 | 1 | test_deletes.test_1
+(1 row)
 
 /* tuple descs are different */
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test WHERE val = 101;
+         QUERY PLAN          
+-----------------------------
+ Delete on test_11
+   ->  Seq Scan on test_11
+         Filter: (val = 101)
+(3 rows)
+
 DELETE FROM test_deletes.test WHERE val = 101 RETURNING *, tableoid::REGCLASS;
+ val | b  |       tableoid       
+-----+----+----------------------
+ 101 | 10 | test_deletes.test_11
+(1 row)
 
 CREATE TABLE test_deletes.test_dummy (val INT4);
-
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test
 WHERE val = 101 AND val = ANY (TABLE test_deletes.test_dummy)
 RETURNING *, tableoid::REGCLASS;
+             QUERY PLAN             
+------------------------------------
+ Delete on test_11
+   ->  Nested Loop Semi Join
+         ->  Seq Scan on test_11
+               Filter: (val = 101)
+         ->  Seq Scan on test_dummy
+               Filter: (val = 101)
+(6 rows)
 
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test t1
 USING test_deletes.test_dummy t2
 WHERE t1.val = 101 AND t1.val = t2.val
 RETURNING t1.*, t1.tableoid::REGCLASS;
+              QUERY PLAN               
+---------------------------------------
+ Delete on test_11 t1
+   ->  Nested Loop
+         ->  Seq Scan on test_11 t1
+               Filter: (val = 101)
+         ->  Seq Scan on test_dummy t2
+               Filter: (val = 101)
+(6 rows)
 
 EXPLAIN (COSTS OFF) DELETE FROM test_deletes.test
 WHERE val = 101 AND test >= (100, 8)
 RETURNING *, tableoid::REGCLASS;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Delete on test_11
+   ->  Seq Scan on test_11
+         Filter: (((test_11.*)::test_deletes.test >= ROW(100, 8)) AND (val = 101))
+(3 rows)
 
 DROP TABLE test_deletes.test_dummy;
-
-
-
 DROP SCHEMA test_deletes CASCADE;
+NOTICE:  drop cascades to 13 other objects
 DROP EXTENSION pg_pathman;

--- a/expected/pathman_rebuild_updates_1.out
+++ b/expected/pathman_rebuild_updates_1.out
@@ -109,6 +109,52 @@ RETURNING test;
 (1 row)
 
 DROP TABLE test_updates.test_dummy;
+/* cross-partition updates (& different tuple descs) */
+TRUNCATE test_updates.test;
+SET pg_pathman.enable_partitionrouter = ON;
+SELECT *, (select count(*) from pg_attribute where attrelid = partition) as columns
+FROM pathman_partition_list
+ORDER BY range_min::int, range_max::int;
+      parent       |      partition       | parttype | expr | range_min | range_max | columns 
+-------------------+----------------------+----------+------+-----------+-----------+---------
+ test_updates.test | test_updates.test_1  |        2 | val  | 1         | 11        |       9
+ test_updates.test | test_updates.test_2  |        2 | val  | 11        | 21        |       9
+ test_updates.test | test_updates.test_3  |        2 | val  | 21        | 31        |       9
+ test_updates.test | test_updates.test_4  |        2 | val  | 31        | 41        |       9
+ test_updates.test | test_updates.test_5  |        2 | val  | 41        | 51        |       9
+ test_updates.test | test_updates.test_6  |        2 | val  | 51        | 61        |       9
+ test_updates.test | test_updates.test_7  |        2 | val  | 61        | 71        |       9
+ test_updates.test | test_updates.test_8  |        2 | val  | 71        | 81        |       9
+ test_updates.test | test_updates.test_9  |        2 | val  | 81        | 91        |       9
+ test_updates.test | test_updates.test_10 |        2 | val  | 91        | 101       |       9
+ test_updates.test | test_updates.test_11 |        2 | val  | 101       | 111       |       8
+(11 rows)
+
+INSERT INTO test_updates.test VALUES (105, 105);
+UPDATE test_updates.test SET val = 106 WHERE val = 105 RETURNING *, tableoid::REGCLASS;
+ val |  b  |       tableoid       
+-----+-----+----------------------
+ 106 | 105 | test_updates.test_11
+(1 row)
+
+UPDATE test_updates.test SET val = 115 WHERE val = 106 RETURNING *, tableoid::REGCLASS;
+ val |  b  |       tableoid       
+-----+-----+----------------------
+ 115 | 105 | test_updates.test_12
+(1 row)
+
+UPDATE test_updates.test SET val =  95 WHERE val = 115 RETURNING *, tableoid::REGCLASS;
+ val |  b  |       tableoid       
+-----+-----+----------------------
+  95 | 105 | test_updates.test_10
+(1 row)
+
+UPDATE test_updates.test SET val =  -1 WHERE val =  95 RETURNING *, tableoid::REGCLASS;
+ val |  b  |       tableoid       
+-----+-----+----------------------
+  -1 | 105 | test_updates.test_13
+(1 row)
+
 DROP SCHEMA test_updates CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DROP EXTENSION pg_pathman;

--- a/expected/pathman_rebuild_updates_1.out
+++ b/expected/pathman_rebuild_updates_1.out
@@ -92,11 +92,11 @@ RETURNING t1.*, t1.tableoid::REGCLASS;
 EXPLAIN (COSTS OFF) UPDATE test_updates.test SET b = 0
 WHERE val = 101 AND test >= (100, 8)
 RETURNING *, tableoid::REGCLASS;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Update on test_11
    ->  Seq Scan on test_11
-         Filter: (((test_11.*)::test_updates.test >= '(100,8)'::record) AND (val = 101))
+         Filter: (((test_11.*)::test_updates.test >= ROW(100, 8)) AND (val = 101))
 (3 rows)
 
 /* execute this one */
@@ -109,52 +109,6 @@ RETURNING test;
 (1 row)
 
 DROP TABLE test_updates.test_dummy;
-/* cross-partition updates (& different tuple descs) */
-TRUNCATE test_updates.test;
-SET pg_pathman.enable_partitionrouter = ON;
-SELECT *, (select count(*) from pg_attribute where attrelid = partition) as columns
-FROM pathman_partition_list
-ORDER BY range_min::int, range_max::int;
-      parent       |      partition       | parttype | expr | range_min | range_max | columns 
--------------------+----------------------+----------+------+-----------+-----------+---------
- test_updates.test | test_updates.test_1  |        2 | val  | 1         | 11        |       9
- test_updates.test | test_updates.test_2  |        2 | val  | 11        | 21        |       9
- test_updates.test | test_updates.test_3  |        2 | val  | 21        | 31        |       9
- test_updates.test | test_updates.test_4  |        2 | val  | 31        | 41        |       9
- test_updates.test | test_updates.test_5  |        2 | val  | 41        | 51        |       9
- test_updates.test | test_updates.test_6  |        2 | val  | 51        | 61        |       9
- test_updates.test | test_updates.test_7  |        2 | val  | 61        | 71        |       9
- test_updates.test | test_updates.test_8  |        2 | val  | 71        | 81        |       9
- test_updates.test | test_updates.test_9  |        2 | val  | 81        | 91        |       9
- test_updates.test | test_updates.test_10 |        2 | val  | 91        | 101       |       9
- test_updates.test | test_updates.test_11 |        2 | val  | 101       | 111       |       8
-(11 rows)
-
-INSERT INTO test_updates.test VALUES (105, 105);
-UPDATE test_updates.test SET val = 106 WHERE val = 105 RETURNING *, tableoid::REGCLASS;
- val |  b  |       tableoid       
------+-----+----------------------
- 106 | 105 | test_updates.test_11
-(1 row)
-
-UPDATE test_updates.test SET val = 115 WHERE val = 106 RETURNING *, tableoid::REGCLASS;
- val |  b  |       tableoid       
------+-----+----------------------
- 115 | 105 | test_updates.test_12
-(1 row)
-
-UPDATE test_updates.test SET val =  95 WHERE val = 115 RETURNING *, tableoid::REGCLASS;
- val |  b  |       tableoid       
------+-----+----------------------
-  95 | 105 | test_updates.test_10
-(1 row)
-
-UPDATE test_updates.test SET val =  -1 WHERE val =  95 RETURNING *, tableoid::REGCLASS;
- val |  b  |       tableoid       
------+-----+----------------------
-  -1 | 105 | test_updates.test_13
-(1 row)
-
 DROP SCHEMA test_updates CASCADE;
-NOTICE:  drop cascades to 15 other objects
+NOTICE:  drop cascades to 13 other objects
 DROP EXTENSION pg_pathman;

--- a/sql/pathman_expressions.sql
+++ b/sql/pathman_expressions.sql
@@ -1,3 +1,10 @@
+/*
+ * -------------------------------------------
+ *  NOTE: This test behaves differenly on < 11 because planner now turns
+ *  Row(Const, Const) into just Const of record type, apparently since 3decd150
+ * -------------------------------------------
+ */
+
 \set VERBOSITY terse
 
 SET search_path = 'public';

--- a/sql/pathman_permissions.sql
+++ b/sql/pathman_permissions.sql
@@ -23,6 +23,7 @@ BEGIN
     SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
 
 /* Grant SELECT to user2 */
@@ -36,6 +37,7 @@ BEGIN
     SELECT create_range_partitions('permissions.user1_table', 'id', 1, 10, 2);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
 
 /* Should be ok */
@@ -64,6 +66,7 @@ BEGIN
     INSERT INTO permissions.user1_table (id, a) VALUES (35, 0);
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
 
 /* No rights to create partitions (need INSERT privilege) */
@@ -101,6 +104,7 @@ BEGIN
     SELECT drop_range_partition('permissions.user1_table_4');
 EXCEPTION
     WHEN insufficient_privilege THEN
+        RAISE NOTICE 'Insufficient priviliges';
 END$$;
 
 /* Disable automatic partition creation */

--- a/sql/pathman_rebuild_updates.sql
+++ b/sql/pathman_rebuild_updates.sql
@@ -1,3 +1,10 @@
+/*
+ * -------------------------------------------
+ *  NOTE: This test behaves differenly on < 11 because planner now turns
+ *  Row(Const, Const) into just Const of record type, apparently since 3decd150
+ * -------------------------------------------
+ */
+
 \set VERBOSITY terse
 
 SET search_path = 'public';

--- a/src/compat/pg_compat.c
+++ b/src/compat/pg_compat.c
@@ -48,7 +48,12 @@ create_plain_partial_paths(PlannerInfo *root, RelOptInfo *rel)
 {
 	int			parallel_workers;
 
+#if PG_VERSION_NUM >= 110000
+	parallel_workers = compute_parallel_worker(rel, rel->pages, -1,
+											   max_parallel_workers_per_gather);
+#else
 	parallel_workers = compute_parallel_worker(rel, rel->pages, -1);
+#endif
 
 	/* If any limit was set to zero, the user doesn't want a parallel scan. */
 	if (parallel_workers <= 0)
@@ -240,7 +245,11 @@ McxtStatsInternal(MemoryContext context, int level,
 	AssertArg(MemoryContextIsValid(context));
 
 	/* Examine the context itself */
+#if PG_VERSION_NUM >= 110000
+	(*context->methods->stats) (context, NULL, NULL, totals);
+#else
 	(*context->methods->stats) (context, level, false, totals);
+#endif
 
 	memset(&local_totals, 0, sizeof(local_totals));
 

--- a/src/compat/pg_compat.c
+++ b/src/compat/pg_compat.c
@@ -48,12 +48,8 @@ create_plain_partial_paths(PlannerInfo *root, RelOptInfo *rel)
 {
 	int			parallel_workers;
 
-#if PG_VERSION_NUM >= 110000
-	parallel_workers = compute_parallel_worker(rel, rel->pages, -1,
-											   max_parallel_workers_per_gather);
-#else
-	parallel_workers = compute_parallel_worker(rel, rel->pages, -1);
-#endif
+	/* no more than max_parallel_workers_per_gather since 11 */
+	parallel_workers = compute_parallel_worker_compat(rel, rel->pages, -1);
 
 	/* If any limit was set to zero, the user doesn't want a parallel scan. */
 	if (parallel_workers <= 0)

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -487,7 +487,7 @@ pathman_rel_pathlist_hook(PlannerInfo *root,
 		memset((void *) &root->append_rel_array[current_len], 0,
 			   irange_len * sizeof(AppendRelInfo *));
 #endif
-		
+
 		/* Don't forget to update array size! */
 		root->simple_rel_array_size = new_len;
 	}
@@ -496,7 +496,7 @@ pathman_rel_pathlist_hook(PlannerInfo *root,
 	parent_rel = heap_open(rte->relid, NoLock);
 
 	parent_rowmark = get_plan_rowmark(root->rowMarks, rti);
-	
+
 	/* Add parent if asked to */
 	if (prel->enable_parent)
 		append_child_relation(root, parent_rel, parent_rowmark,

--- a/src/include/compat/pg_compat.h
+++ b/src/include/compat/pg_compat.h
@@ -808,7 +808,7 @@ extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 	generate_gather_paths((root), (rel), false)
 #elif PG_VERSION_NUM >= 90600
 #define generate_gather_paths_compat(root, rel) \
-	generate_gather_paths((rel), (heap_pages), false)
+	generate_gather_paths((root), (rel))
 #else
 #define generate_gather_paths_compat(root, rel)
 #endif

--- a/src/include/compat/pg_compat.h
+++ b/src/include/compat/pg_compat.h
@@ -788,6 +788,45 @@ extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 #endif
 
 /*
+ * compute_parallel_worker
+ */
+#if PG_VERSION_NUM >= 110000
+#define compute_parallel_worker_compat(rel, heap_pages, index_pages) \
+	compute_parallel_worker((rel), (heap_pages), (index_pages), \
+							max_parallel_workers_per_gather)
+#elif PG_VERSION_NUM >= 100000
+#define compute_parallel_worker_compat(rel, heap_pages, index_pages) \
+	compute_parallel_worker((rel), (heap_pages), (index_pages))
+#endif
+
+
+/*
+ * generate_gather_paths
+ */
+#if PG_VERSION_NUM >= 110000
+#define generate_gather_paths_compat(root, rel) \
+	generate_gather_paths((root), (rel), false)
+#elif PG_VERSION_NUM >= 90600
+#define generate_gather_paths_compat(root, rel) \
+	generate_gather_paths((rel), (heap_pages), false)
+#else
+#define generate_gather_paths_compat(root, rel)
+#endif
+
+
+/*
+ * handling appendrelinfo array
+ */
+#if PG_VERSION_NUM >= 110000
+#define find_childrel_appendrelinfo_compat(root, rel) \
+	((root)->append_rel_array[(rel)->relid])
+#else
+#define find_childrel_appendrelinfo_compat(root, rel) \
+		find_childrel_appendrelinfo((root), (rel))
+#endif
+
+
+/*
  * -------------
  *  Common code
  * -------------

--- a/src/include/hooks.h
+++ b/src/include/hooks.h
@@ -42,7 +42,7 @@ void pathman_rel_pathlist_hook(PlannerInfo *root,
 							   Index rti,
 							   RangeTblEntry *rte);
 
-void pathman_enable_assign_hook(char newval, void *extra);
+void pathman_enable_assign_hook(bool newval, void *extra);
 
 PlannedStmt * pathman_planner_hook(Query *parse,
 								   int cursorOptions,

--- a/src/include/partition_filter.h
+++ b/src/include/partition_filter.h
@@ -29,7 +29,7 @@
 
 
 #define ERR_PART_ATTR_NULL				"partitioning expression's value should not be NULL"
-#define ERR_PART_ATTR_MULTIPLE_RESULTS	"partitioning expression should return single value"
+#define ERR_PART_ATTR_MULTIPLE_RESULTS
 #define ERR_PART_ATTR_NO_PART			"no suitable partition for key '%s'"
 #define ERR_PART_ATTR_MULTIPLE			INSERT_NODE_NAME " selected more than one partition"
 #define ERR_PART_DESC_CONVERT			"could not convert row type for partition"

--- a/src/include/relation_info.h
+++ b/src/include/relation_info.h
@@ -11,10 +11,10 @@
 #ifndef RELATION_INFO_H
 #define RELATION_INFO_H
 
+#include "compat/pg_compat.h"
 
 #include "utils.h"
 
-#include "postgres.h"
 #include "access/attnum.h"
 #include "access/sysattr.h"
 #include "fmgr.h"
@@ -279,7 +279,7 @@ PrelExpressionColumnNames(const PartRelationInfo *prel)
 	while ((i = bms_next_member(prel->expr_atts, i)) >= 0)
 	{
 		AttrNumber	attnum = i + FirstLowInvalidHeapAttributeNumber;
-		char	   *attname = get_attname(PrelParentRelid(prel), attnum);
+		char	   *attname = get_attname_compat(PrelParentRelid(prel), attnum);
 
 		columns = lappend(columns, makeString(attname));
 	}

--- a/src/init.c
+++ b/src/init.c
@@ -25,9 +25,6 @@
 #include "catalog/indexing.h"
 #include "catalog/pg_extension.h"
 #include "catalog/pg_inherits.h"
-#if PG_VERSION_NUM < 110000
-#include "catalog/pg_inherits_fn.h"
-#endif
 #include "catalog/pg_type.h"
 #include "miscadmin.h"
 #include "optimizer/clauses.h"
@@ -39,6 +36,9 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#if PG_VERSION_NUM < 110000
+#include "catalog/pg_inherits_fn.h"
+#endif
 
 #include <stdlib.h>
 

--- a/src/init.c
+++ b/src/init.c
@@ -25,7 +25,9 @@
 #include "catalog/indexing.h"
 #include "catalog/pg_extension.h"
 #include "catalog/pg_inherits.h"
+#if PG_VERSION_NUM < 110000
 #include "catalog/pg_inherits_fn.h"
+#endif
 #include "catalog/pg_type.h"
 #include "miscadmin.h"
 #include "optimizer/clauses.h"

--- a/src/nodes_common.c
+++ b/src/nodes_common.c
@@ -569,11 +569,9 @@ create_append_plan_common(PlannerInfo *root, RelOptInfo *rel,
 		{
 			Plan		   *child_plan = (Plan *) lfirst(lc2);
 			RelOptInfo	   *child_rel = ((Path *) lfirst(lc1))->parent;
-#if PG_VERSION_NUM >= 110000
-			AppendRelInfo *appinfo = root->append_rel_array[child_rel->relid];
-#else
-			AppendRelInfo  *appinfo = find_childrel_appendrelinfo(root, child_rel);
-#endif
+			AppendRelInfo  *appinfo;
+
+			appinfo = find_childrel_appendrelinfo_compat(root, child_rel);
 
 			/* Replace rel's tlist with a matching one (for ExecQual()) */
 			if (!processed_rel_tlist)

--- a/src/nodes_common.c
+++ b/src/nodes_common.c
@@ -568,8 +568,12 @@ create_append_plan_common(PlannerInfo *root, RelOptInfo *rel,
 		forboth (lc1, rpath->cpath.custom_paths, lc2, custom_plans)
 		{
 			Plan		   *child_plan = (Plan *) lfirst(lc2);
-			RelOptInfo 	   *child_rel = ((Path *) lfirst(lc1))->parent;
+			RelOptInfo	   *child_rel = ((Path *) lfirst(lc1))->parent;
+#if PG_VERSION_NUM >= 110000
+			AppendRelInfo *appinfo = root->append_rel_array[child_rel->relid];
+#else
 			AppendRelInfo  *appinfo = find_childrel_appendrelinfo(root, child_rel);
+#endif
 
 			/* Replace rel's tlist with a matching one (for ExecQual()) */
 			if (!processed_rel_tlist)

--- a/src/partition_router.c
+++ b/src/partition_router.c
@@ -160,7 +160,7 @@ partition_router_exec(CustomScanState *node)
 			state->junkfilter =
 				ExecInitJunkFilter(state->subplan->targetlist,
 								   old_rri->ri_RelationDesc->rd_att->tdhasoid,
-								   ExecInitExtraTupleSlot(estate));
+								   ExecInitExtraTupleSlotCompat(estate));
 
 			state->junkfilter->jf_junkAttNo =
 				ExecFindJunkAttribute(state->junkfilter, "ctid");
@@ -277,11 +277,11 @@ ExecDeleteInternal(ItemPointer tupleid,
 	{
 		/* delete the tuple */
 ldelete:
-		result = heap_delete(resultRelationDesc, tupleid,
-							 estate->es_output_cid,
-							 estate->es_crosscheck_snapshot,
-							 true /* wait for commit */ ,
-							 &hufd);
+		result = heap_delete_compat(resultRelationDesc, tupleid,
+									estate->es_output_cid,
+									estate->es_crosscheck_snapshot,
+									true /* wait for commit */ ,
+									&hufd);
 		switch (result)
 		{
 			case HeapTupleSelfUpdated:

--- a/src/pathman_workers.c
+++ b/src/pathman_workers.c
@@ -384,7 +384,7 @@ bgw_main_spawn_partitions(Datum main_arg)
 #endif
 	/* Establish connection and start transaction */
 
-	BackgroundWorkerInitializeConnectionByOid(args->dbid, args->userid);
+	BackgroundWorkerInitializeConnectionByOidCompat(args->dbid, args->userid);
 
 	/* Start new transaction (syscache access etc.) */
 	StartTransactionCommand();
@@ -469,7 +469,7 @@ bgw_main_concurrent_part(Datum main_arg)
 	SetAutoPartitionEnabled(false);
 
 	/* Establish connection and start transaction */
-	BackgroundWorkerInitializeConnectionByOid(part_slot->dbid, part_slot->userid);
+	BackgroundWorkerInitializeConnectionByOidCompat(part_slot->dbid, part_slot->userid);
 
 	/* Initialize pg_pathman's local config */
 	StartTransactionCommand();
@@ -483,7 +483,7 @@ bgw_main_concurrent_part(Datum main_arg)
 
 		Oid		types[2]	= { OIDOID,				INT4OID };
 		Datum	vals[2]		= { part_slot->relid,	part_slot->batch_size };
-		bool	nulls[2]	= { false,				false };
+		char	nulls[2]	= { false,				false };
 
 		bool	rel_locked = false;
 
@@ -568,7 +568,7 @@ bgw_main_concurrent_part(Datum main_arg)
 
 				/* Extract number of processed rows */
 				rows = DatumGetInt64(SPI_getbinval(tuple, tupdesc, 1, &isnull));
-				Assert(tupdesc->attrs[0]->atttypid == INT8OID); /* check type */
+				Assert(TupleDescAttr(tupdesc, 0)->atttypid == INT8OID); /* check type */
 				Assert(!isnull); /* ... and ofc it must not be NULL */
 			}
 			/* Else raise generic error */

--- a/src/pathman_workers.c
+++ b/src/pathman_workers.c
@@ -483,7 +483,6 @@ bgw_main_concurrent_part(Datum main_arg)
 
 		Oid		types[2]	= { OIDOID,				INT4OID };
 		Datum	vals[2]		= { part_slot->relid,	part_slot->batch_size };
-		char	nulls[2]	= { false,				false };
 
 		bool	rel_locked = false;
 
@@ -557,7 +556,7 @@ bgw_main_concurrent_part(Datum main_arg)
 			}
 
 			/* Call concurrent partitioning function */
-			ret = SPI_execute_with_args(sql, 2, types, vals, nulls, false, 0);
+			ret = SPI_execute_with_args(sql, 2, types, vals, NULL, false, 0);
 			if (ret == SPI_OK_SELECT)
 			{
 				TupleDesc	tupdesc	= SPI_tuptable->tupdesc;

--- a/src/pg_pathman.c
+++ b/src/pg_pathman.c
@@ -535,6 +535,10 @@ append_child_relation(PlannerInfo *root,
 
 	/* Now append 'appinfo' to 'root->append_rel_list' */
 	root->append_rel_list = lappend(root->append_rel_list, appinfo);
+	/* And to array in >= 11, it must be big enough */
+#if PG_VERSION_NUM >= 110000
+	root->append_rel_array[child_rti] = appinfo;
+#endif
 
 	/* Translate column privileges for this child */
 	if (parent_rte->relid != child_oid)

--- a/src/pl_funcs.c
+++ b/src/pl_funcs.c
@@ -23,7 +23,9 @@
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#if PG_VERSION_NUM < 110000
 #include "catalog/pg_inherits_fn.h"
+#endif
 #include "catalog/pg_type.h"
 #include "commands/tablespace.h"
 #include "commands/trigger.h"

--- a/src/pl_range_funcs.c
+++ b/src/pl_range_funcs.c
@@ -18,7 +18,9 @@
 #include "access/xact.h"
 #include "catalog/heap.h"
 #include "catalog/namespace.h"
+#if PG_VERSION_NUM < 110000
 #include "catalog/pg_inherits_fn.h"
+#endif
 #include "catalog/pg_type.h"
 #include "commands/tablecmds.h"
 #include "executor/spi.h"

--- a/src/relation_info.c
+++ b/src/relation_info.c
@@ -20,9 +20,6 @@
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_constraint.h"
-#if PG_VERSION_NUM < 110000 && PG_VERSION_NUM >= 90600
-#include "catalog/pg_constraint_fn.h"
-#endif
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_type.h"
 #include "miscadmin.h"
@@ -47,8 +44,7 @@
 #if PG_VERSION_NUM < 90600
 #include "optimizer/planmain.h"
 #endif
-
-#if PG_VERSION_NUM >= 90600 && PG_VERSION_NUM < 11000
+#if PG_VERSION_NUM < 110000 && PG_VERSION_NUM >= 90600
 #include "catalog/pg_constraint_fn.h"
 #endif
 

--- a/src/utility_stmt_hooking.c
+++ b/src/utility_stmt_hooking.c
@@ -514,10 +514,10 @@ PathmanCopyFrom(CopyState cstate, Relation parent_rel,
 							  RPS_RRI_CB(finish_rri_for_copy, NULL));
 
 	/* Set up a tuple slot too */
-	myslot = ExecInitExtraTupleSlot(estate);
+	myslot = ExecInitExtraTupleSlotCompat(estate);
 	ExecSetSlotDescriptor(myslot, tupDesc);
 	/* Triggers might need a slot as well */
-	estate->es_trig_tuple_slot = ExecInitExtraTupleSlot(estate);
+	estate->es_trig_tuple_slot = ExecInitExtraTupleSlotCompat(estate);
 
 	/* Prepare to catch AFTER triggers. */
 	AfterTriggerBeginQuery();

--- a/tests/python/Makefile
+++ b/tests/python/Makefile
@@ -1,2 +1,2 @@
 partitioning_tests:
-	python -m unittest partitioning_test.py
+	python -m unittest --verbose --failfast partitioning_test.py

--- a/tests/python/partitioning_test.py
+++ b/tests/python/partitioning_test.py
@@ -650,7 +650,7 @@ class Tests(unittest.TestCase):
 
                 # Thread for connection #2 (it has to wait)
                 def con2_thread():
-                    con1.begin()
+                    con2.begin()
                     con2.execute('set enable_hashjoin = f')
                     con2.execute('set enable_mergejoin = f')
 


### PR DESCRIPTION
I kinda lost interest to exorcise a couple of tests further in attempts to make
them pass on all supported versions and just added copies. These are
 * pathman_expressions now differs because planner converts ROW(Const, Const) to
   just Const of record type.
 * Same with pathman_rebuild_updates.

I have removed inclusion of partition_filter.h in pg_compat.h in 9.5 as it
created circular dependency hell. I think it is not worthwhile to fight with it
since the only thing actually needed was error message, which is used in this
single place.

Small typo fix in partitioning_test.py: con2.begin instead of con1.begin.

Finally, run python tests with --failfast and --verbose options.