### PR TITLE
Changed lock order for MERGE of range partitions + change for issue #247

### DIFF
--- a/src/pl_range_funcs.c
+++ b/src/pl_range_funcs.c
@@ -683,9 +683,6 @@ merge_range_partitions(PG_FUNCTION_ARGS)
 		/* Extract partition Oids from array */
 		parts[i] = DatumGetObjectId(datums[i]);
 
-		/* Prevent modification of partitions */
-		LockRelationOid(parts[i], AccessExclusiveLock);
-
 		/* Check if all partitions are from the same parent */
 		cur_parent = get_parent_of_partition(parts[i]);
 
@@ -707,6 +704,10 @@ merge_range_partitions(PG_FUNCTION_ARGS)
 
 	/* Prevent changes in partitioning scheme */
 	LockRelationOid(parent, ShareUpdateExclusiveLock);
+
+	/* Prevent modification of partitions */
+	for (i = 0; i < nparts; i++)
+		LockRelationOid(parts[i], AccessExclusiveLock);
 
 	/* Emit an error if it is not partitioned by RANGE */
 	prel = get_pathman_relation_info(parent);

--- a/src/utility_stmt_hooking.c
+++ b/src/utility_stmt_hooking.c
@@ -114,7 +114,11 @@ is_pathman_related_copy(Node *parsetree)
 									(copy_stmt->is_from ?
 										PATHMAN_COPY_WRITE_LOCK :
 										PATHMAN_COPY_READ_LOCK),
-									false);
+									true);
+
+	/* Skip relation if it does not exist (for Citus compatibility) */
+	if (!OidIsValid(parent_relid))
+		return false;
 
 	/* Check that relation is partitioned */
 	if (has_pathman_relation_info(parent_relid))


### PR DESCRIPTION
1) Changed lock order for MERGE of range partitions: the parent table is locked first and then are locked the partitions.
2) Change for issue #247: need to skip non-existing relations for Citus compatibility.