### PR TITLE
PGPRO-6148, PGPRO-7080: Use common macro for all PG versions instead of add_vars_to_targetlist() function

### DIFF
--- a/src/compat/rowmarks_fix.c
+++ b/src/compat/rowmarks_fix.c
@@ -47,7 +47,7 @@ append_tle_for_rowmark(PlannerInfo *root, PlanRowMark *rc)
 
 	root->processed_tlist = lappend(root->processed_tlist, tle);
 
-	add_vars_to_targetlist(root, list_make1(var), bms_make_singleton(0), true);
+	add_vars_to_targetlist_compat(root, list_make1(var), bms_make_singleton(0));
 }
 
 

--- a/src/include/compat/rowmarks_fix.h
+++ b/src/include/compat/rowmarks_fix.h
@@ -45,5 +45,17 @@ void append_tle_for_rowmark(PlannerInfo *root, PlanRowMark *rc);
 
 #endif
 
+/*
+ * add_vars_to_targetlist()
+ * In >=16 last argument was removed (b3ff6c742f6c)
+ */
+#if PG_VERSION_NUM >= 160000
+#define add_vars_to_targetlist_compat(root, vars, where_needed) \
+	add_vars_to_targetlist((root), (vars), (where_needed));
+#else
+#define add_vars_to_targetlist_compat(root, vars, where_needed) \
+	add_vars_to_targetlist((root), (vars), (where_needed), true);
+#endif
+
 
 #endif /* ROWMARKS_FIX_H */


### PR DESCRIPTION
PGPRO-6148, PGPRO-7080: Use common macro for all PG versions instead of add_vars_to_targetlist() function.

Reason: b3ff6c74