### PR TITLE
Fix build due to new checks in PostgreSQL 16

### DIFF
--- a/src/pl_funcs.c
+++ b/src/pl_funcs.c
@@ -179,7 +179,7 @@ get_partition_cooked_key_pl(PG_FUNCTION_ARGS)
 	pfree(expr_cstr);
 	pfree(expr);
 
-	PG_RETURN_TEXT_P(CStringGetTextDatum(cooked_cstr));
+	PG_RETURN_DATUM(CStringGetTextDatum(cooked_cstr));
 }
 
 /*
@@ -199,7 +199,7 @@ get_cached_partition_cooked_key_pl(PG_FUNCTION_ARGS)
 	res = CStringGetTextDatum(nodeToString(prel->expr));
 	close_pathman_relation_info(prel);
 
-	PG_RETURN_TEXT_P(res);
+	PG_RETURN_DATUM(res);
 }
 
 /*
@@ -688,7 +688,7 @@ validate_expression(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(1))
 	{
-		expression = TextDatumGetCString(PG_GETARG_TEXT_P(1));
+		expression = TextDatumGetCString(PG_GETARG_DATUM(1));
 	}
 	else ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("'expression' should not be NULL")));
@@ -818,7 +818,7 @@ add_to_pathman_config(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(1))
 	{
-		expression = TextDatumGetCString(PG_GETARG_TEXT_P(1));
+		expression = TextDatumGetCString(PG_GETARG_DATUM(1));
 	}
 	else ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("'expression' should not be NULL")));
@@ -1203,7 +1203,7 @@ is_operator_supported(PG_FUNCTION_ARGS)
 {
 	Oid		opid,
 			typid	= PG_GETARG_OID(0);
-	char   *opname	= TextDatumGetCString(PG_GETARG_TEXT_P(1));
+	char   *opname	= TextDatumGetCString(PG_GETARG_DATUM(1));
 
 	opid = compatible_oper_opid(list_make1(makeString(opname)),
 								typid, typid, true);

--- a/src/pl_hash_funcs.c
+++ b/src/pl_hash_funcs.c
@@ -119,7 +119,7 @@ Datum
 build_hash_condition(PG_FUNCTION_ARGS)
 {
 	Oid				expr_type	= PG_GETARG_OID(0);
-	char		   *expr_cstr	= TextDatumGetCString(PG_GETARG_TEXT_P(1));
+	char		   *expr_cstr	= TextDatumGetCString(PG_GETARG_DATUM(1));
 	uint32			part_count	= PG_GETARG_UINT32(2),
 					part_idx	= PG_GETARG_UINT32(3);
 

--- a/src/pl_range_funcs.c
+++ b/src/pl_range_funcs.c
@@ -156,7 +156,7 @@ create_single_range_partition_pl(PG_FUNCTION_ARGS)
 	/* Fetch 'tablespace' */
 	if (!PG_ARGISNULL(4))
 	{
-		tablespace = TextDatumGetCString(PG_GETARG_TEXT_P(4));
+		tablespace = TextDatumGetCString(PG_GETARG_DATUM(4));
 	}
 	else tablespace = NULL; /* default */
 
@@ -429,7 +429,7 @@ validate_interval_value(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("'expression' should not be NULL")));
 	}
-	else expr_cstr = TextDatumGetCString(PG_GETARG_TEXT_P(ARG_EXPRESSION));
+	else expr_cstr = TextDatumGetCString(PG_GETARG_DATUM(ARG_EXPRESSION));
 
 	if (PG_ARGISNULL(ARG_PARTTYPE))
 	{
@@ -1086,7 +1086,7 @@ build_range_condition(PG_FUNCTION_ARGS)
 
 	if (!PG_ARGISNULL(1))
 	{
-		expression = TextDatumGetCString(PG_GETARG_TEXT_P(1));
+		expression = TextDatumGetCString(PG_GETARG_DATUM(1));
 	}
 	else ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("'expression' should not be NULL")));;


### PR DESCRIPTION
Due to the commit c8b2ef05f481ef06326d7b9f3eb14b303f215c7e in PostgreSQL 16:

- The macro CStringGetTextDatum returns a Datum, so use the more appropriate macro PG_RETURN_DATUM instead of PG_RETURN_TEXT_P.

- The input to the macro TextDatumGetCString must be of type Datum, so use the more appropriate macro PG_GETARG_DATUM instead of PG_GETARG_TEXT_P.