### PR TITLE
Fix compiler warnings due to new checks in PostgreSQL 16

### DIFF
--- a/src/partition_creation.c
+++ b/src/partition_creation.c
@@ -2027,11 +2027,9 @@ build_partitioning_expression(Oid parent_relid,
 	/* We need expression type for hash functions */
 	if (expr_type)
 	{
-		Node	*expr;
-		expr = cook_partitioning_expression(parent_relid, expr_cstr, NULL);
-
 		/* Finally return expression type */
-		*expr_type = exprType(expr);
+		*expr_type = exprType(
+			cook_partitioning_expression(parent_relid, expr_cstr, NULL));
 	}
 
 	if (columns)

--- a/src/relation_info.c
+++ b/src/relation_info.c
@@ -71,34 +71,34 @@ int				prel_resowner_line = 0;
 
 #define LeakTrackerAdd(prel) \
 	do { \
-		MemoryContext old_mcxt = MemoryContextSwitchTo((prel)->mcxt); \
+		MemoryContext leak_tracker_add_old_mcxt = MemoryContextSwitchTo((prel)->mcxt); \
 		(prel)->owners = \
 				list_append_unique( \
 						(prel)->owners, \
 						list_make2(makeString((char *) prel_resowner_function), \
 								   makeInteger(prel_resowner_line))); \
-		MemoryContextSwitchTo(old_mcxt); \
+		MemoryContextSwitchTo(leak_tracker_add_old_mcxt); \
 		\
 		(prel)->access_total++; \
 	} while (0)
 
 #define LeakTrackerPrint(prel) \
 	do { \
-		ListCell *lc; \
-		foreach (lc, (prel)->owners) \
+		ListCell *leak_tracker_print_lc; \
+		foreach (leak_tracker_print_lc, (prel)->owners) \
 		{ \
-			char   *fun = strVal(linitial(lfirst(lc))); \
-			int		line = intVal(lsecond(lfirst(lc))); \
+			char   *fun = strVal(linitial(lfirst(leak_tracker_print_lc))); \
+			int		line = intVal(lsecond(lfirst(leak_tracker_print_lc))); \
 			elog(WARNING, "PartRelationInfo referenced in %s:%d", fun, line); \
 		} \
 	} while (0)
 
 #define LeakTrackerFree(prel) \
 	do { \
-		ListCell *lc; \
-		foreach (lc, (prel)->owners) \
+		ListCell *leak_tracker_free_lc; \
+		foreach (leak_tracker_free_lc, (prel)->owners) \
 		{ \
-			list_free_deep(lfirst(lc)); \
+			list_free_deep(lfirst(leak_tracker_free_lc)); \
 		} \
 		list_free((prel)->owners); \
 		(prel)->owners = NIL; \

--- a/src/runtime_merge_append.c
+++ b/src/runtime_merge_append.c
@@ -374,7 +374,8 @@ fetch_next_tuple(CustomScanState *node)
 		for (i = 0; i < scan_state->rstate.ncur_plans; i++)
 		{
 			ChildScanCommon		child = scan_state->rstate.cur_plans[i];
-			PlanState		   *ps = child->content.plan_state;
+
+			ps = child->content.plan_state;
 
 			Assert(child->content_type == CHILD_PLAN_STATE);
 
@@ -721,9 +722,10 @@ prepare_sort_from_pathkeys(PlannerInfo *root, Plan *lefttree, List *pathkeys,
 
 			foreach(j, ec->ec_members)
 			{
-				EquivalenceMember *em = (EquivalenceMember *) lfirst(j);
 				List	   *exprvars;
 				ListCell   *k;
+
+				em = (EquivalenceMember *) lfirst(j);
 
 				/*
 				 * We shouldn't be trying to sort by an equivalence class that


### PR DESCRIPTION
See the commit 0fe954c28584169938e5c0738cfaa9930ce77577 (Add -Wshadow=compatible-local to the standard compilation flags) in PostgreSQL 16.

```
src/relation_info.c: In function ‘resowner_prel_add’:
src/relation_info.c:74:31: warning: declaration of ‘old_mcxt’ shadows a previous local [-Wshadow=compatible-local]
   74 |                 MemoryContext old_mcxt = MemoryContextSwitchTo((prel)->mcxt); \
      |                               ^~~~~~~~
src/relation_info.c:608:17: note: in expansion of macro ‘LeakTrackerAdd’
  608 |                 LeakTrackerAdd(prel);
      |                 ^~~~~~~~~~~~~~
src/relation_info.c:592:41: note: shadowed declaration is here
  592 |                 MemoryContext           old_mcxt;
      |                                         ^~~~~~~~
src/relation_info.c: In function ‘resonwner_prel_callback’:
src/relation_info.c:87:27: warning: declaration of ‘lc’ shadows a previous local [-Wshadow=compatible-local]
   87 |                 ListCell *lc; \
      |                           ^~
src/relation_info.c:691:41: note: in expansion of macro ‘LeakTrackerPrint’
  691 |                                         LeakTrackerPrint(prel);
      |                                         ^~~~~~~~~~~~~~~~
src/relation_info.c:675:27: note: shadowed declaration is here
  675 |                 ListCell *lc;
      |                           ^~
In file included from /home/marina/postgresql/postgresql/my/inst/include/server/access/tupdesc.h:19,
                 from /home/marina/pg_pathman/src/include/compat/pg_compat.h:25,
                 from src/relation_info.c:11:
src/relation_info.c:88:26: warning: declaration of ‘lc__state’ shadows a previous local [-Wshadow=compatible-local]
   88 |                 foreach (lc, (prel)->owners) \
      |                          ^~
/home/marina/postgresql/postgresql/my/inst/include/server/nodes/pg_list.h:372:27: note: in definition of macro ‘foreach’
  372 |         for (ForEachState cell##__state = {(lst), 0}; \
      |                           ^~~~
src/relation_info.c:691:41: note: in expansion of macro ‘LeakTrackerPrint’
  691 |                                         LeakTrackerPrint(prel);
      |                                         ^~~~~~~~~~~~~~~~
src/relation_info.c:684:34: note: shadowed declaration is here
  684 |                         foreach (lc, info->prels)
      |                                  ^~
/home/marina/postgresql/postgresql/my/inst/include/server/nodes/pg_list.h:372:27: note: in definition of macro ‘foreach’
  372 |         for (ForEachState cell##__state = {(lst), 0}; \
      |                           ^~~~
src/relation_info.c:98:27: warning: declaration of ‘lc’ shadows a previous local [-Wshadow=compatible-local]
   98 |                 ListCell *lc; \
      |                           ^~
src/relation_info.c:705:33: note: in expansion of macro ‘LeakTrackerFree’
  705 |                                 LeakTrackerFree(prel);
      |                                 ^~~~~~~~~~~~~~~
src/relation_info.c:675:27: note: shadowed declaration is here
  675 |                 ListCell *lc;
      |                           ^~
In file included from /home/marina/postgresql/postgresql/my/inst/include/server/access/tupdesc.h:19,
                 from /home/marina/pg_pathman/src/include/compat/pg_compat.h:25,
                 from src/relation_info.c:11:
src/relation_info.c:99:26: warning: declaration of ‘lc__state’ shadows a previous local [-Wshadow=compatible-local]
   99 |                 foreach (lc, (prel)->owners) \
      |                          ^~
/home/marina/postgresql/postgresql/my/inst/include/server/nodes/pg_list.h:372:27: note: in definition of macro ‘foreach’
  372 |         for (ForEachState cell##__state = {(lst), 0}; \
      |                           ^~~~
src/relation_info.c:705:33: note: in expansion of macro ‘LeakTrackerFree’
  705 |                                 LeakTrackerFree(prel);
      |                                 ^~~~~~~~~~~~~~~
src/relation_info.c:684:34: note: shadowed declaration is here
  684 |                         foreach (lc, info->prels)
      |                                  ^~
/home/marina/postgresql/postgresql/my/inst/include/server/nodes/pg_list.h:372:27: note: in definition of macro ‘foreach’
  372 |         for (ForEachState cell##__state = {(lst), 0}; \
      |                           ^~~~
src/runtime_merge_append.c: In function ‘fetch_next_tuple’:
src/runtime_merge_append.c:377:53: warning: declaration of ‘ps’ shadows a previous local [-Wshadow=compatible-local]
  377 |                         PlanState                  *ps = child->content.plan_state;
      |                                                     ^~
src/runtime_merge_append.c:369:53: note: shadowed declaration is here
  369 |         PlanState                                  *ps;
      |                                                     ^~
src/runtime_merge_append.c: In function ‘prepare_sort_from_pathkeys’:
src/runtime_merge_append.c:724:52: warning: declaration of ‘em’ shadows a previous local [-Wshadow=compatible-local]
  724 |                                 EquivalenceMember *em = (EquivalenceMember *) lfirst(j);
      |                                                    ^~
src/runtime_merge_append.c:635:36: note: shadowed declaration is here
  635 |                 EquivalenceMember *em;
      |                                    ^~
src/partition_creation.c: In function ‘build_partitioning_expression’:
src/partition_creation.c:2030:26: warning: declaration of ‘expr’ shadows a previous local [-Wshadow=compatible-local]
 2030 |                 Node    *expr;
      |                          ^~~~
src/partition_creation.c:2017:21: note: shadowed declaration is here
 2017 |         Node       *expr;
      |                     ^~~~
```