### PR TITLE
Fixes related to new changes in PostgreSQL 16: October 25, 2022 - November 15, 2022

### DIFF
--- a/expected/pathman_join_clause_4.out
+++ b/expected/pathman_join_clause_4.out
@@ -1,0 +1,161 @@
+/*
+ * Since 8edd0e794 (>= 12) Append nodes with single subplan are eliminated,
+ * causing different output; pathman_gaps_1.out is the updated version.
+ */
+\set VERBOSITY terse
+SET search_path = 'public';
+CREATE SCHEMA pathman;
+CREATE EXTENSION pg_pathman SCHEMA pathman;
+CREATE SCHEMA test;
+/*
+ * Test push down a join clause into child nodes of append
+ */
+/* create test tables */
+CREATE TABLE test.fk (
+	id1 INT NOT NULL,
+	id2 INT NOT NULL,
+	start_key INT,
+	end_key INT,
+	PRIMARY KEY (id1, id2));
+CREATE TABLE test.mytbl (
+	id1 INT NOT NULL,
+	id2 INT NOT NULL,
+	key INT NOT NULL,
+	CONSTRAINT fk_fk FOREIGN KEY (id1, id2) REFERENCES test.fk(id1, id2),
+	PRIMARY KEY (id1, key));
+SELECT pathman.create_hash_partitions('test.mytbl', 'id1', 8);
+ create_hash_partitions 
+------------------------
+                      8
+(1 row)
+
+/* ...fill out with test data */
+INSERT INTO test.fk VALUES (1, 1);
+INSERT INTO test.mytbl VALUES (1, 1, 5), (1, 1, 6);
+/* gather statistics on test tables to have deterministic plans */
+ANALYZE;
+/* run test queries */
+EXPLAIN (COSTS OFF)     /* test plan */
+SELECT m.tableoid::regclass, id1, id2, key, start_key, end_key
+FROM test.mytbl m JOIN test.fk USING(id1, id2)
+WHERE NOT key <@ int4range(6, end_key);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Seq Scan on fk
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (m.id1 = fk.id1)
+         ->  Seq Scan on mytbl_0 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_1 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_2 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_3 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_4 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_5 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_6 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+         ->  Seq Scan on mytbl_7 m
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+(20 rows)
+
+/* test joint data */
+SELECT m.tableoid::regclass, id1, id2, key, start_key, end_key
+FROM test.mytbl m JOIN test.fk USING(id1, id2)
+WHERE NOT key <@ int4range(6, end_key);
+   tableoid   | id1 | id2 | key | start_key | end_key 
+--------------+-----+-----+-----+-----------+---------
+ test.mytbl_6 |   1 |   1 |   5 |           |        
+(1 row)
+
+/*
+ * Test case by @dimarick
+ */
+CREATE TABLE test.parent (
+  id SERIAL NOT NULL,
+  owner_id INTEGER NOT NULL
+);
+CREATE TABLE test.child (
+  parent_id INTEGER NOT NULL,
+  owner_id INTEGER NOT NULL
+);
+CREATE TABLE test.child_nopart (
+  parent_id INTEGER NOT NULL,
+  owner_id INTEGER NOT NULL
+);
+INSERT INTO test.parent (owner_id) VALUES (1), (2), (3), (3);
+INSERT INTO test.child (parent_id, owner_id) VALUES (1, 1), (2, 2), (3, 3), (5, 3);
+INSERT INTO test.child_nopart (parent_id, owner_id) VALUES (1, 1), (2, 2), (3, 3), (5, 3);
+SELECT pathman.create_hash_partitions('test.child', 'owner_id', 2);
+ create_hash_partitions 
+------------------------
+                      2
+(1 row)
+
+/* gather statistics on test tables to have deterministic plans */
+ANALYZE;
+/* Query #1 */
+EXPLAIN (COSTS OFF) SELECT * FROM test.parent
+LEFT JOIN test.child ON test.child.parent_id = test.parent.id AND
+						test.child.owner_id = test.parent.owner_id
+WHERE test.parent.owner_id = 3 and test.parent.id IN (3, 4);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Seq Scan on parent
+         Filter: ((id = ANY ('{3,4}'::integer[])) AND (owner_id = 3))
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: ((child.owner_id = 3) AND (child.owner_id = parent.owner_id))
+         ->  Seq Scan on child_1 child
+               Filter: ((owner_id = 3) AND (owner_id = parent.owner_id) AND (parent_id = parent.id))
+(7 rows)
+
+SELECT * FROM test.parent
+LEFT JOIN test.child ON test.child.parent_id = test.parent.id AND
+						test.child.owner_id = test.parent.owner_id
+WHERE test.parent.owner_id = 3 and test.parent.id IN (3, 4);
+ id | owner_id | parent_id | owner_id 
+----+----------+-----------+----------
+  3 |        3 |         3 |        3
+  4 |        3 |           |         
+(2 rows)
+
+/* Query #2 */
+EXPLAIN (COSTS OFF) SELECT * FROM test.parent
+LEFT JOIN test.child ON test.child.parent_id = test.parent.id AND
+						test.child.owner_id = 3
+WHERE test.parent.owner_id = 3 and test.parent.id IN (3, 4);
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Nested Loop Left Join
+   Join Filter: (child.parent_id = parent.id)
+   ->  Seq Scan on parent
+         Filter: ((id = ANY ('{3,4}'::integer[])) AND (owner_id = 3))
+   ->  Seq Scan on child_1 child
+         Filter: (owner_id = 3)
+(6 rows)
+
+SELECT * FROM test.parent
+LEFT JOIN test.child ON test.child.parent_id = test.parent.id AND
+						test.child.owner_id = 3
+WHERE test.parent.owner_id = 3 and test.parent.id IN (3, 4);
+ id | owner_id | parent_id | owner_id 
+----+----------+-----------+----------
+  3 |        3 |         3 |        3
+  4 |        3 |           |         
+(2 rows)
+
+DROP TABLE test.child CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP TABLE test.child_nopart CASCADE;
+DROP TABLE test.mytbl CASCADE;
+NOTICE:  drop cascades to 8 other objects
+DROP TABLE test.fk CASCADE;
+DROP TABLE test.parent CASCADE;
+DROP SCHEMA test;
+DROP EXTENSION pg_pathman CASCADE;
+DROP SCHEMA pathman;

--- a/expected/pathman_lateral_4.out
+++ b/expected/pathman_lateral_4.out
@@ -1,0 +1,128 @@
+/*
+ * Sometimes join selectivity improvements patches in pgpro force nested loop
+ * members swap -- in pathman_lateral_1.out and pathman_lateral_3.out
+ *
+ * Since 55a1954da16 and 6ef77cf46e8 (>= 13) output of EXPLAIN was changed,
+ * now it includes aliases for inherited tables.
+ */
+\set VERBOSITY terse
+SET search_path = 'public';
+CREATE EXTENSION pg_pathman;
+CREATE SCHEMA test_lateral;
+/* create table partitioned by HASH */
+create table test_lateral.data(id int8 not null);
+select create_hash_partitions('test_lateral.data', 'id', 10);
+ create_hash_partitions 
+------------------------
+                     10
+(1 row)
+
+insert into test_lateral.data select generate_series(1, 10000);
+VACUUM ANALYZE;
+set enable_hashjoin = off;
+set enable_mergejoin = off;
+/* all credits go to Ivan Frolkov */
+explain (costs off)
+select * from
+	test_lateral.data as t1,
+	lateral(select * from test_lateral.data as t2 where t2.id > t1.id) t2,
+	lateral(select * from test_lateral.data as t3 where t3.id = t2.id + t1.id) t3
+			where t1.id between 1 and 100 and
+				  t2.id between 2 and 299 and
+				  t1.id > t2.id and
+				  exists(select * from test_lateral.data t
+						 where t1.id = t2.id and t.id = t3.id);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Nested Loop
+         Join Filter: ((t2.id + t1.id) = t.id)
+         ->  HashAggregate
+               Group Key: t.id
+               ->  Append
+                     ->  Seq Scan on data_0 t_1
+                     ->  Seq Scan on data_1 t_2
+                     ->  Seq Scan on data_2 t_3
+                     ->  Seq Scan on data_3 t_4
+                     ->  Seq Scan on data_4 t_5
+                     ->  Seq Scan on data_5 t_6
+                     ->  Seq Scan on data_6 t_7
+                     ->  Seq Scan on data_7 t_8
+                     ->  Seq Scan on data_8 t_9
+                     ->  Seq Scan on data_9 t_10
+         ->  Materialize
+               ->  Nested Loop
+                     Join Filter: ((t2.id > t1.id) AND (t1.id > t2.id) AND (t1.id = t2.id))
+                     ->  Append
+                           ->  Seq Scan on data_0 t2_1
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_1 t2_2
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_2 t2_3
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_3 t2_4
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_4 t2_5
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_5 t2_6
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_6 t2_7
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_7 t2_8
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_8 t2_9
+                                 Filter: ((id >= 2) AND (id <= 299))
+                           ->  Seq Scan on data_9 t2_10
+                                 Filter: ((id >= 2) AND (id <= 299))
+                     ->  Materialize
+                           ->  Append
+                                 ->  Seq Scan on data_0 t1_1
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_1 t1_2
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_2 t1_3
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_3 t1_4
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_4 t1_5
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_5 t1_6
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_6 t1_7
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_7 t1_8
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_8 t1_9
+                                       Filter: ((id >= 1) AND (id <= 100))
+                                 ->  Seq Scan on data_9 t1_10
+                                       Filter: ((id >= 1) AND (id <= 100))
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (t3.id = t.id)
+         ->  Seq Scan on data_0 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_1 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_2 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_3 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_4 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_5 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_6 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_7 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_8 t3
+               Filter: (t.id = id)
+         ->  Seq Scan on data_9 t3
+               Filter: (t.id = id)
+(84 rows)
+
+set enable_hashjoin = on;
+set enable_mergejoin = on;
+DROP TABLE test_lateral.data CASCADE;
+NOTICE:  drop cascades to 10 other objects
+DROP SCHEMA test_lateral;
+DROP EXTENSION pg_pathman;

--- a/expected/pathman_only_3.out
+++ b/expected/pathman_only_3.out
@@ -1,0 +1,281 @@
+/*
+ * ---------------------------------------------
+ *  NOTE: This test behaves differenly on PgPro
+ * ---------------------------------------------
+ *
+ * Since 12 (608b167f9f), CTEs which are scanned once are no longer an
+ * optimization fence, which changes practically all plans here. There is
+ * an option to forcibly make them MATERIALIZED, but we also need to run tests
+ * on older versions, so create pathman_only_1.out instead.
+ *
+ * Since 55a1954da16 and 6ef77cf46e8 (>= 13) output of EXPLAIN was changed,
+ * now it includes aliases for inherited tables.
+ */
+\set VERBOSITY terse
+SET search_path = 'public';
+CREATE EXTENSION pg_pathman;
+CREATE SCHEMA test_only;
+/* Test special case: ONLY statement with not-ONLY for partitioned table */
+CREATE TABLE test_only.from_only_test(val INT NOT NULL);
+INSERT INTO test_only.from_only_test SELECT generate_series(1, 20);
+SELECT create_range_partitions('test_only.from_only_test', 'val', 1, 2);
+ create_range_partitions 
+-------------------------
+                      10
+(1 row)
+
+VACUUM ANALYZE;
+/* should be OK */
+EXPLAIN (COSTS OFF)
+SELECT * FROM ONLY test_only.from_only_test
+UNION SELECT * FROM test_only.from_only_test;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ HashAggregate
+   Group Key: from_only_test.val
+   ->  Append
+         ->  Seq Scan on from_only_test
+         ->  Append
+               ->  Seq Scan on from_only_test_1 from_only_test_2
+               ->  Seq Scan on from_only_test_2 from_only_test_3
+               ->  Seq Scan on from_only_test_3 from_only_test_4
+               ->  Seq Scan on from_only_test_4 from_only_test_5
+               ->  Seq Scan on from_only_test_5 from_only_test_6
+               ->  Seq Scan on from_only_test_6 from_only_test_7
+               ->  Seq Scan on from_only_test_7 from_only_test_8
+               ->  Seq Scan on from_only_test_8 from_only_test_9
+               ->  Seq Scan on from_only_test_9 from_only_test_10
+               ->  Seq Scan on from_only_test_10 from_only_test_11
+(15 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+SELECT * FROM test_only.from_only_test
+UNION SELECT * FROM ONLY test_only.from_only_test;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ HashAggregate
+   Group Key: from_only_test.val
+   ->  Append
+         ->  Append
+               ->  Seq Scan on from_only_test_1
+               ->  Seq Scan on from_only_test_2
+               ->  Seq Scan on from_only_test_3
+               ->  Seq Scan on from_only_test_4
+               ->  Seq Scan on from_only_test_5
+               ->  Seq Scan on from_only_test_6
+               ->  Seq Scan on from_only_test_7
+               ->  Seq Scan on from_only_test_8
+               ->  Seq Scan on from_only_test_9
+               ->  Seq Scan on from_only_test_10
+         ->  Seq Scan on from_only_test from_only_test_11
+(15 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+SELECT * FROM test_only.from_only_test
+UNION SELECT * FROM test_only.from_only_test
+UNION SELECT * FROM ONLY test_only.from_only_test;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ HashAggregate
+   Group Key: from_only_test.val
+   ->  Append
+         ->  Append
+               ->  Seq Scan on from_only_test_1
+               ->  Seq Scan on from_only_test_2
+               ->  Seq Scan on from_only_test_3
+               ->  Seq Scan on from_only_test_4
+               ->  Seq Scan on from_only_test_5
+               ->  Seq Scan on from_only_test_6
+               ->  Seq Scan on from_only_test_7
+               ->  Seq Scan on from_only_test_8
+               ->  Seq Scan on from_only_test_9
+               ->  Seq Scan on from_only_test_10
+         ->  Append
+               ->  Seq Scan on from_only_test_1 from_only_test_12
+               ->  Seq Scan on from_only_test_2 from_only_test_13
+               ->  Seq Scan on from_only_test_3 from_only_test_14
+               ->  Seq Scan on from_only_test_4 from_only_test_15
+               ->  Seq Scan on from_only_test_5 from_only_test_16
+               ->  Seq Scan on from_only_test_6 from_only_test_17
+               ->  Seq Scan on from_only_test_7 from_only_test_18
+               ->  Seq Scan on from_only_test_8 from_only_test_19
+               ->  Seq Scan on from_only_test_9 from_only_test_20
+               ->  Seq Scan on from_only_test_10 from_only_test_21
+         ->  Seq Scan on from_only_test from_only_test_22
+(26 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+SELECT * FROM ONLY test_only.from_only_test
+UNION SELECT * FROM test_only.from_only_test
+UNION SELECT * FROM test_only.from_only_test;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ HashAggregate
+   Group Key: from_only_test.val
+   ->  Append
+         ->  Seq Scan on from_only_test
+         ->  Append
+               ->  Seq Scan on from_only_test_1 from_only_test_2
+               ->  Seq Scan on from_only_test_2 from_only_test_3
+               ->  Seq Scan on from_only_test_3 from_only_test_4
+               ->  Seq Scan on from_only_test_4 from_only_test_5
+               ->  Seq Scan on from_only_test_5 from_only_test_6
+               ->  Seq Scan on from_only_test_6 from_only_test_7
+               ->  Seq Scan on from_only_test_7 from_only_test_8
+               ->  Seq Scan on from_only_test_8 from_only_test_9
+               ->  Seq Scan on from_only_test_9 from_only_test_10
+               ->  Seq Scan on from_only_test_10 from_only_test_11
+         ->  Append
+               ->  Seq Scan on from_only_test_1 from_only_test_13
+               ->  Seq Scan on from_only_test_2 from_only_test_14
+               ->  Seq Scan on from_only_test_3 from_only_test_15
+               ->  Seq Scan on from_only_test_4 from_only_test_16
+               ->  Seq Scan on from_only_test_5 from_only_test_17
+               ->  Seq Scan on from_only_test_6 from_only_test_18
+               ->  Seq Scan on from_only_test_7 from_only_test_19
+               ->  Seq Scan on from_only_test_8 from_only_test_20
+               ->  Seq Scan on from_only_test_9 from_only_test_21
+               ->  Seq Scan on from_only_test_10 from_only_test_22
+(26 rows)
+
+/* not ok, ONLY|non-ONLY in one query (this is not the case for PgPro) */
+EXPLAIN (COSTS OFF)
+SELECT * FROM test_only.from_only_test a
+JOIN ONLY test_only.from_only_test b USING(val);
+                 QUERY PLAN                  
+---------------------------------------------
+ Nested Loop
+   ->  Seq Scan on from_only_test b
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (a.val = b.val)
+         ->  Seq Scan on from_only_test_1 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_2 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_3 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_4 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_5 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_6 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_7 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_8 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_9 a
+               Filter: (b.val = val)
+         ->  Seq Scan on from_only_test_10 a
+               Filter: (b.val = val)
+(24 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+WITH q1 AS (SELECT * FROM test_only.from_only_test),
+	 q2 AS (SELECT * FROM ONLY test_only.from_only_test)
+SELECT * FROM q1 JOIN q2 USING(val);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Nested Loop
+   ->  Seq Scan on from_only_test from_only_test_1
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (from_only_test.val = from_only_test_1.val)
+         ->  Seq Scan on from_only_test_1 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_2 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_3 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_4 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_5 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_6 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_7 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_8 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_9 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_10 from_only_test
+               Filter: (from_only_test_1.val = val)
+(24 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+WITH q1 AS (SELECT * FROM ONLY test_only.from_only_test)
+SELECT * FROM test_only.from_only_test JOIN q1 USING(val);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Nested Loop
+   ->  Seq Scan on from_only_test from_only_test_1
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (from_only_test.val = from_only_test_1.val)
+         ->  Seq Scan on from_only_test_1 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_2 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_3 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_4 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_5 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_6 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_7 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_8 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_9 from_only_test
+               Filter: (from_only_test_1.val = val)
+         ->  Seq Scan on from_only_test_10 from_only_test
+               Filter: (from_only_test_1.val = val)
+(24 rows)
+
+/* should be OK */
+EXPLAIN (COSTS OFF)
+SELECT * FROM test_only.from_only_test
+WHERE val = (SELECT val FROM ONLY test_only.from_only_test
+			 ORDER BY val ASC
+			 LIMIT 1);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Custom Scan (RuntimeAppend)
+   Prune by: (from_only_test.val = $0)
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Sort
+                 Sort Key: from_only_test_1.val
+                 ->  Seq Scan on from_only_test from_only_test_1
+   ->  Seq Scan on from_only_test_1 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_2 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_3 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_4 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_5 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_6 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_7 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_8 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_9 from_only_test
+         Filter: (val = $0)
+   ->  Seq Scan on from_only_test_10 from_only_test
+         Filter: (val = $0)
+(27 rows)
+
+DROP TABLE test_only.from_only_test CASCADE;
+NOTICE:  drop cascades to 11 other objects
+DROP SCHEMA test_only;
+DROP EXTENSION pg_pathman;

--- a/expected/pathman_runtime_nodes_1.out
+++ b/expected/pathman_runtime_nodes_1.out
@@ -1,0 +1,468 @@
+\set VERBOSITY terse
+SET search_path = 'public';
+CREATE SCHEMA pathman;
+CREATE EXTENSION pg_pathman SCHEMA pathman;
+CREATE SCHEMA test;
+/*
+ * Test RuntimeAppend
+ */
+create or replace function test.pathman_assert(smt bool, error_msg text) returns text as $$
+begin
+	if not smt then
+		raise exception '%', error_msg;
+	end if;
+
+	return 'ok';
+end;
+$$ language plpgsql;
+create or replace function test.pathman_equal(a text, b text, error_msg text) returns text as $$
+begin
+	if a != b then
+		raise exception '''%'' is not equal to ''%'', %', a, b, error_msg;
+	end if;
+
+	return 'equal';
+end;
+$$ language plpgsql;
+create or replace function test.pathman_test(query text) returns jsonb as $$
+declare
+	plan jsonb;
+begin
+	execute 'explain (analyze, format json)' || query into plan;
+
+	return plan;
+end;
+$$ language plpgsql;
+create or replace function test.pathman_test_1() returns text as $$
+declare
+	plan jsonb;
+	num int;
+begin
+	plan = test.pathman_test('select * from test.runtime_test_1 where id = (select * from test.run_values limit 1)');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Node Type')::text,
+							   '"Custom Scan"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Custom Plan Provider')::text,
+							   '"RuntimeAppend"',
+							   'wrong plan provider');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Relation Name')::text,
+							   format('"runtime_test_1_%s"', pathman.get_hash_part_idx(hashint4(1), 6)),
+							   'wrong partition');
+
+	select count(*) from jsonb_array_elements_text(plan->0->'Plan'->'Plans') into num;
+	perform test.pathman_equal(num::text, '2', 'expected 2 child plans for custom scan');
+
+	return 'ok';
+end;
+$$ language plpgsql
+set pg_pathman.enable = true
+set enable_mergejoin = off
+set enable_hashjoin = off;
+create or replace function test.pathman_test_2() returns text as $$
+declare
+	plan jsonb;
+	num int;
+	c text;
+begin
+	plan = test.pathman_test('select * from test.runtime_test_1 where id = any (select * from test.run_values limit 4)');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Node Type')::text,
+							   '"Nested Loop"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Node Type')::text,
+							   '"Custom Scan"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Custom Plan Provider')::text,
+							   '"RuntimeAppend"',
+							   'wrong plan provider');
+
+	select count(*) from jsonb_array_elements_text(plan->0->'Plan'->'Plans'->1->'Plans') into num;
+	perform test.pathman_equal(num::text, '4', 'expected 4 child plans for custom scan');
+
+	execute 'select string_agg(y.z, '','') from
+				(select (x->''Relation Name'')::text as z from
+					jsonb_array_elements($1->0->''Plan''->''Plans''->1->''Plans'') x
+				 order by x->''Relation Name'') y'
+		into c using plan;
+	perform test.pathman_equal(c, '"runtime_test_1_2","runtime_test_1_3","runtime_test_1_4","runtime_test_1_5"',
+								'wrong partitions');
+
+	for i in 0..3 loop
+		num = plan->0->'Plan'->'Plans'->1->'Plans'->i->'Actual Loops';
+		perform test.pathman_equal(num::text, '1', 'expected 1 loop');
+	end loop;
+
+	return 'ok';
+end;
+$$ language plpgsql
+set pg_pathman.enable = true
+set enable_mergejoin = off
+set enable_hashjoin = off;
+create or replace function test.pathman_test_3() returns text as $$
+declare
+	plan jsonb;
+	num int;
+begin
+	plan = test.pathman_test('select * from test.runtime_test_1 a join test.run_values b on a.id = b.val');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Node Type')::text,
+							   '"Nested Loop"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Node Type')::text,
+							   '"Custom Scan"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Custom Plan Provider')::text,
+							   '"RuntimeAppend"',
+							   'wrong plan provider');
+
+	select count(*) from jsonb_array_elements_text(plan->0->'Plan'->'Plans'->1->'Plans') into num;
+	perform test.pathman_equal(num::text, '6', 'expected 6 child plans for custom scan');
+
+	for i in 0..5 loop
+		num = plan->0->'Plan'->'Plans'->1->'Plans'->i->'Actual Loops';
+		perform test.pathman_assert(num > 0 and num <= 1718, 'expected no more than 1718 loops');
+	end loop;
+
+	return 'ok';
+end;
+$$ language plpgsql
+set pg_pathman.enable = true
+set enable_mergejoin = off
+set enable_hashjoin = off;
+create or replace function test.pathman_test_4() returns text as $$
+declare
+	plan jsonb;
+	num int;
+begin
+	plan = test.pathman_test('select * from test.category c, lateral' ||
+							 '(select * from test.runtime_test_2 g where g.category_id = c.id order by rating limit 4) as tg');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Node Type')::text,
+							   '"Nested Loop"',
+							   'wrong plan type');
+
+														/* Limit -> Custom Scan */
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->0->'Node Type')::text,
+							   '"Custom Scan"',
+							   'wrong plan type');
+
+	perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->0->'Custom Plan Provider')::text,
+							   '"RuntimeMergeAppend"',
+							   'wrong plan provider');
+
+	select count(*) from jsonb_array_elements_text(plan->0->'Plan'->'Plans'->1->'Plans'->0->'Plans') into num;
+	perform test.pathman_equal(num::text, '4', 'expected 4 child plans for custom scan');
+
+	for i in 0..3 loop
+		perform test.pathman_equal((plan->0->'Plan'->'Plans'->1->'Plans'->0->'Plans'->i->'Relation Name')::text,
+								   format('"runtime_test_2_%s"', pathman.get_hash_part_idx(hashint4(i + 1), 6)),
+								   'wrong partition');
+
+		num = plan->0->'Plan'->'Plans'->1->'Plans'->0->'Plans'->i->'Actual Loops';
+		perform test.pathman_assert(num = 1, 'expected no more than 1 loops');
+	end loop;
+
+	return 'ok';
+end;
+$$ language plpgsql
+set pg_pathman.enable = true
+set enable_mergejoin = off
+set enable_hashjoin = off;
+create or replace function test.pathman_test_5() returns text as $$
+declare
+	res record;
+begin
+	select
+	from test.runtime_test_3
+	where id = (select * from test.vals order by val limit 1)
+	limit 1
+	into res; /* test empty tlist */
+
+
+	select id * 2, id, 17
+	from test.runtime_test_3
+	where id = (select * from test.vals order by val limit 1)
+	limit 1
+	into res; /* test computations */
+
+
+	select test.vals.* from test.vals, lateral (select from test.runtime_test_3
+												where id = test.vals.val) as q
+	into res; /* test lateral */
+
+
+	select id, generate_series(1, 2) gen, val
+	from test.runtime_test_3
+	where id = (select * from test.vals order by val limit 1)
+	order by id, gen, val
+	offset 1 limit 1
+	into res; /* without IndexOnlyScan */
+
+	perform test.pathman_equal(res.id::text, '1', 'id is incorrect (t2)');
+	perform test.pathman_equal(res.gen::text, '2', 'gen is incorrect (t2)');
+	perform test.pathman_equal(res.val::text, 'k = 1', 'val is incorrect (t2)');
+
+
+	select id
+	from test.runtime_test_3
+	where id = any (select * from test.vals order by val limit 5)
+	order by id
+	offset 3 limit 1
+	into res; /* with IndexOnlyScan */
+
+	perform test.pathman_equal(res.id::text, '4', 'id is incorrect (t3)');
+
+
+	select v.val v1, generate_series(2, 2) gen, t.val v2
+	from test.runtime_test_3 t join test.vals v on id = v.val
+	order by v1, gen, v2
+	limit 1
+	into res;
+
+	perform test.pathman_equal(res.v1::text, '1', 'v1 is incorrect (t4)');
+	perform test.pathman_equal(res.gen::text, '2', 'gen is incorrect (t4)');
+	perform test.pathman_equal(res.v2::text, 'k = 1', 'v2 is incorrect (t4)');
+
+	return 'ok';
+end;
+$$ language plpgsql
+set pg_pathman.enable = true
+set enable_hashjoin = off
+set enable_mergejoin = off;
+create table test.run_values as select generate_series(1, 10000) val;
+create table test.runtime_test_1(id serial primary key, val real);
+insert into test.runtime_test_1 select generate_series(1, 10000), random();
+select pathman.create_hash_partitions('test.runtime_test_1', 'id', 6);
+ create_hash_partitions 
+------------------------
+                      6
+(1 row)
+
+create table test.category as (select id, 'cat' || id::text as name from generate_series(1, 4) id);
+create table test.runtime_test_2 (id serial, category_id int not null, name text, rating real);
+insert into test.runtime_test_2 (select id, (id % 6) + 1 as category_id, 'good' || id::text as name, random() as rating from generate_series(1, 100000) id);
+create index on test.runtime_test_2 (category_id, rating);
+select pathman.create_hash_partitions('test.runtime_test_2', 'category_id', 6);
+ create_hash_partitions 
+------------------------
+                      6
+(1 row)
+
+create table test.vals as (select generate_series(1, 10000) as val);
+create table test.runtime_test_3(val text, id serial not null);
+insert into test.runtime_test_3(id, val) select * from generate_series(1, 10000) k, format('k = %s', k);
+select pathman.create_hash_partitions('test.runtime_test_3', 'id', 4);
+ create_hash_partitions 
+------------------------
+                      4
+(1 row)
+
+create index on test.runtime_test_3 (id);
+create index on test.runtime_test_3_0 (id);
+create table test.runtime_test_4(val text, id int not null);
+insert into test.runtime_test_4(id, val) select * from generate_series(1, 10000) k, md5(k::text);
+select pathman.create_range_partitions('test.runtime_test_4', 'id', 1, 2000);
+ create_range_partitions 
+-------------------------
+                       5
+(1 row)
+
+VACUUM ANALYZE;
+set pg_pathman.enable_runtimeappend = on;
+set pg_pathman.enable_runtimemergeappend = on;
+select test.pathman_test_1(); /* RuntimeAppend (select ... where id = (subquery)) */
+ pathman_test_1 
+----------------
+ ok
+(1 row)
+
+select test.pathman_test_2(); /* RuntimeAppend (select ... where id = any(subquery)) */
+ pathman_test_2 
+----------------
+ ok
+(1 row)
+
+select test.pathman_test_3(); /* RuntimeAppend (a join b on a.id = b.val) */
+ pathman_test_3 
+----------------
+ ok
+(1 row)
+
+select test.pathman_test_4(); /* RuntimeMergeAppend (lateral) */
+ pathman_test_4 
+----------------
+ ok
+(1 row)
+
+select test.pathman_test_5(); /* projection tests for RuntimeXXX nodes */
+ pathman_test_5 
+----------------
+ ok
+(1 row)
+
+/* RuntimeAppend (join, enabled parent) */
+select pathman.set_enable_parent('test.runtime_test_1', true);
+ set_enable_parent 
+-------------------
+ 
+(1 row)
+
+explain (costs off)
+select from test.runtime_test_1 as t1
+join (select * from test.run_values limit 4) as t2 on t1.id = t2.val;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Nested Loop
+   ->  Limit
+         ->  Seq Scan on run_values
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (t1.id = run_values.val)
+         ->  Seq Scan on runtime_test_1 t1
+               Filter: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_0_pkey on runtime_test_1_0 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_1_pkey on runtime_test_1_1 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_2_pkey on runtime_test_1_2 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_3_pkey on runtime_test_1_3 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_4_pkey on runtime_test_1_4 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_5_pkey on runtime_test_1_5 t1
+               Index Cond: (id = run_values.val)
+(19 rows)
+
+select from test.runtime_test_1 as t1
+join (select * from test.run_values limit 4) as t2 on t1.id = t2.val;
+--
+(4 rows)
+
+/* RuntimeAppend (join, disabled parent) */
+select pathman.set_enable_parent('test.runtime_test_1', false);
+ set_enable_parent 
+-------------------
+ 
+(1 row)
+
+explain (costs off)
+select from test.runtime_test_1 as t1
+join (select * from test.run_values limit 4) as t2 on t1.id = t2.val;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Nested Loop
+   ->  Limit
+         ->  Seq Scan on run_values
+   ->  Custom Scan (RuntimeAppend)
+         Prune by: (t1.id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_0_pkey on runtime_test_1_0 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_1_pkey on runtime_test_1_1 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_2_pkey on runtime_test_1_2 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_3_pkey on runtime_test_1_3 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_4_pkey on runtime_test_1_4 t1
+               Index Cond: (id = run_values.val)
+         ->  Index Only Scan using runtime_test_1_5_pkey on runtime_test_1_5 t1
+               Index Cond: (id = run_values.val)
+(17 rows)
+
+select from test.runtime_test_1 as t1
+join (select * from test.run_values limit 4) as t2 on t1.id = t2.val;
+--
+(4 rows)
+
+/* RuntimeAppend (join, additional projections) */
+select generate_series(1, 2) from test.runtime_test_1 as t1
+join (select * from test.run_values limit 4) as t2 on t1.id = t2.val;
+ generate_series 
+-----------------
+               1
+               2
+               1
+               2
+               1
+               2
+               1
+               2
+(8 rows)
+
+/* RuntimeAppend (select ... where id = ANY (subquery), missing partitions) */
+select count(*) = 0 from pathman.pathman_partition_list
+where parent = 'test.runtime_test_4'::regclass and coalesce(range_min::int, 1) < 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+/* RuntimeAppend (check that dropped columns don't break tlists) */
+create table test.dropped_cols(val int4 not null);
+select pathman.create_hash_partitions('test.dropped_cols', 'val', 4);
+ create_hash_partitions 
+------------------------
+                      4
+(1 row)
+
+insert into test.dropped_cols select generate_series(1, 100);
+alter table test.dropped_cols add column new_col text;	/* add column */
+alter table test.dropped_cols drop column new_col;		/* drop column! */
+explain (costs off) select * from generate_series(1, 10) f(id), lateral (select count(1) FILTER (WHERE true) from test.dropped_cols where val = f.id) c;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Nested Loop
+   ->  Function Scan on generate_series f
+   ->  Aggregate
+         ->  Custom Scan (RuntimeAppend)
+               Prune by: (dropped_cols.val = f.id)
+               ->  Seq Scan on dropped_cols_0 dropped_cols
+                     Filter: (val = f.id)
+               ->  Seq Scan on dropped_cols_1 dropped_cols
+                     Filter: (val = f.id)
+               ->  Seq Scan on dropped_cols_2 dropped_cols
+                     Filter: (val = f.id)
+               ->  Seq Scan on dropped_cols_3 dropped_cols
+                     Filter: (val = f.id)
+(13 rows)
+
+drop table test.dropped_cols cascade;
+NOTICE:  drop cascades to 4 other objects
+set enable_hashjoin = off;
+set enable_mergejoin = off;
+select from test.runtime_test_4
+where id = any (select generate_series(-10, -1)); /* should be empty */
+--
+(0 rows)
+
+set enable_hashjoin = on;
+set enable_mergejoin = on;
+DROP TABLE test.vals CASCADE;
+DROP TABLE test.category CASCADE;
+DROP TABLE test.run_values CASCADE;
+DROP TABLE test.runtime_test_1 CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DROP TABLE test.runtime_test_2 CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DROP TABLE test.runtime_test_3 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DROP TABLE test.runtime_test_4 CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DROP FUNCTION test.pathman_assert(bool, text);
+DROP FUNCTION test.pathman_equal(text, text, text);
+DROP FUNCTION test.pathman_test(text);
+DROP FUNCTION test.pathman_test_1();
+DROP FUNCTION test.pathman_test_2();
+DROP FUNCTION test.pathman_test_3();
+DROP FUNCTION test.pathman_test_4();
+DROP FUNCTION test.pathman_test_5();
+DROP SCHEMA test;
+DROP EXTENSION pg_pathman CASCADE;
+DROP SCHEMA pathman;

--- a/src/compat/pg_compat.c
+++ b/src/compat/pg_compat.c
@@ -234,7 +234,7 @@ McxtStatsInternal(MemoryContext context, int level,
 	MemoryContextCounters	local_totals;
 	MemoryContext			child;
 
-	AssertArg(MemoryContextIsValid(context));
+	Assert(MemoryContextIsValid(context));
 
 	/* Examine the context itself */
 #if PG_VERSION_NUM >= 140000

--- a/src/init.c
+++ b/src/init.c
@@ -569,7 +569,7 @@ find_inheritance_children_array(Oid parent_relid,
 char *
 build_check_constraint_name_relid_internal(Oid relid)
 {
-	AssertArg(OidIsValid(relid));
+	Assert(OidIsValid(relid));
 	return build_check_constraint_name_relname_internal(get_rel_name(relid));
 }
 
@@ -580,7 +580,7 @@ build_check_constraint_name_relid_internal(Oid relid)
 char *
 build_check_constraint_name_relname_internal(const char *relname)
 {
-	AssertArg(relname != NULL);
+	Assert(relname != NULL);
 	return psprintf("pathman_%s_check", relname);
 }
 
@@ -591,7 +591,7 @@ build_check_constraint_name_relname_internal(const char *relname)
 char *
 build_sequence_name_relid_internal(Oid relid)
 {
-	AssertArg(OidIsValid(relid));
+	Assert(OidIsValid(relid));
 	return build_sequence_name_relname_internal(get_rel_name(relid));
 }
 
@@ -602,7 +602,7 @@ build_sequence_name_relid_internal(Oid relid)
 char *
 build_sequence_name_relname_internal(const char *relname)
 {
-	AssertArg(relname != NULL);
+	Assert(relname != NULL);
 	return psprintf("%s_seq", relname);
 }
 
@@ -613,7 +613,7 @@ build_sequence_name_relname_internal(const char *relname)
 char *
 build_update_trigger_name_internal(Oid relid)
 {
-	AssertArg(OidIsValid(relid));
+	Assert(OidIsValid(relid));
 	return psprintf("%s_upd_trig", get_rel_name(relid));
 }
 
@@ -624,7 +624,7 @@ build_update_trigger_name_internal(Oid relid)
 char *
 build_update_trigger_func_name_internal(Oid relid)
 {
-	AssertArg(OidIsValid(relid));
+	Assert(OidIsValid(relid));
 	return psprintf("%s_upd_trig_func", get_rel_name(relid));
 }
 

--- a/src/nodes_common.c
+++ b/src/nodes_common.c
@@ -59,7 +59,7 @@ transform_plans_into_states(RuntimeAppendState *scan_state,
 		ChildScanCommon		child;
 		PlanState		   *ps;
 
-		AssertArg(selected_plans);
+		Assert(selected_plans);
 		child = selected_plans[i];
 
 		/* Create new node since this plan hasn't been used yet */

--- a/src/partition_creation.c
+++ b/src/partition_creation.c
@@ -2035,7 +2035,7 @@ build_partitioning_expression(Oid parent_relid,
 	if (columns)
 	{
 		/* Column list should be empty */
-		AssertArg(*columns == NIL);
+		Assert(*columns == NIL);
 		extract_column_names(expr, columns);
 	}
 

--- a/src/partition_router.c
+++ b/src/partition_router.c
@@ -63,7 +63,7 @@
 
 
 
-bool				pg_pathman_enable_partition_router = true;
+bool				pg_pathman_enable_partition_router = false;
 
 CustomScanMethods	partition_router_plan_methods;
 CustomExecMethods	partition_router_exec_methods;

--- a/src/pg_pathman.c
+++ b/src/pg_pathman.c
@@ -696,7 +696,7 @@ append_child_relation(PlannerInfo *root,
 #endif
 
 	/* Here and below we assume that parent RelOptInfo exists */
-	AssertState(parent_rel);
+	Assert(parent_rel);
 
 	/* Adjust join quals for this child */
 	child_rel->joininfo = (List *) adjust_appendrel_attrs_compat(root,

--- a/src/relation_info.c
+++ b/src/relation_info.c
@@ -304,7 +304,7 @@ invalidate_psin_entry(PartStatusInfo *psin)
 void
 close_pathman_relation_info(PartRelationInfo *prel)
 {
-	AssertArg(prel);
+	Assert(prel);
 
 	(void) resowner_prel_del(prel);
 }


### PR DESCRIPTION
The commit d3536253d948ba0289e7ad82ae256d8c2b9cd12a was added to fix regression.diffs after running the tests:

```
diff -U3 /home/marina/pg_pathman/expected/pathman_join_clause_2.out /home/marina/pg_pathman/results/pathman_join_clause.out
--- /home/marina/pg_pathman/expected/pathman_join_clause_2.out	2022-11-21 14:11:54.399449877 +0300
+++ /home/marina/pg_pathman/results/pathman_join_clause.out	2022-12-14 09:14:34.999078710 +0300
@@ -44,23 +44,23 @@
  Nested Loop
    ->  Seq Scan on fk
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (fk.id1 = m.id1)
+         Prune by: (m.id1 = fk.id1)
          ->  Seq Scan on mytbl_0 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_1 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_2 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_3 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_4 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_5 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_6 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
          ->  Seq Scan on mytbl_7 m
-               Filter: ((fk.id1 = id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
+               Filter: ((id1 = fk.id1) AND (fk.id2 = id2) AND (NOT (key <@ int4range(6, fk.end_key))))
 (20 rows)
 
 /* test joint data */
diff -U3 /home/marina/pg_pathman/expected/pathman_lateral_2.out /home/marina/pg_pathman/results/pathman_lateral.out
--- /home/marina/pg_pathman/expected/pathman_lateral_2.out	2022-11-21 14:11:54.399449877 +0300
+++ /home/marina/pg_pathman/results/pathman_lateral.out	2022-12-14 09:14:35.351061632 +0300
@@ -97,7 +97,7 @@
                                  ->  Seq Scan on data_9 t1_10
                                        Filter: ((id >= 1) AND (id <= 100))
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (t_1.id = t3.id)
+         Prune by: (t3.id = t_1.id)
          ->  Seq Scan on data_0 t3
                Filter: (t_1.id = id)
          ->  Seq Scan on data_1 t3
diff -U3 /home/marina/pg_pathman/expected/pathman_only_2.out /home/marina/pg_pathman/results/pathman_only.out
--- /home/marina/pg_pathman/expected/pathman_only_2.out	2022-11-21 14:11:54.399449877 +0300
+++ /home/marina/pg_pathman/results/pathman_only.out	2022-12-14 09:14:36.207020217 +0300
@@ -150,7 +150,7 @@
  Nested Loop
    ->  Seq Scan on from_only_test b
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (b.val = a.val)
+         Prune by: (a.val = b.val)
          ->  Seq Scan on from_only_test_1 a
                Filter: (b.val = val)
          ->  Seq Scan on from_only_test_2 a
@@ -183,7 +183,7 @@
  Nested Loop
    ->  Seq Scan on from_only_test from_only_test_1
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (from_only_test_1.val = from_only_test.val)
+         Prune by: (from_only_test.val = from_only_test_1.val)
          ->  Seq Scan on from_only_test_1 from_only_test
                Filter: (from_only_test_1.val = val)
          ->  Seq Scan on from_only_test_2 from_only_test
@@ -215,7 +215,7 @@
  Nested Loop
    ->  Seq Scan on from_only_test from_only_test_1
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (from_only_test_1.val = from_only_test.val)
+         Prune by: (from_only_test.val = from_only_test_1.val)
          ->  Seq Scan on from_only_test_1 from_only_test
                Filter: (from_only_test_1.val = val)
          ->  Seq Scan on from_only_test_2 from_only_test
diff -U3 /home/marina/pg_pathman/expected/pathman_runtime_nodes.out /home/marina/pg_pathman/results/pathman_runtime_nodes.out
--- /home/marina/pg_pathman/expected/pathman_runtime_nodes.out	2022-11-21 14:11:54.399449877 +0300
+++ /home/marina/pg_pathman/results/pathman_runtime_nodes.out	2022-12-14 09:14:40.970796775 +0300
@@ -323,9 +323,9 @@
    ->  Limit
          ->  Seq Scan on run_values
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (run_values.val = t1.id)
+         Prune by: (t1.id = run_values.val)
          ->  Seq Scan on runtime_test_1 t1
-               Filter: (run_values.val = id)
+               Filter: (id = run_values.val)
          ->  Index Only Scan using runtime_test_1_0_pkey on runtime_test_1_0 t1
                Index Cond: (id = run_values.val)
          ->  Index Only Scan using runtime_test_1_1_pkey on runtime_test_1_1 t1
@@ -361,7 +361,7 @@
    ->  Limit
          ->  Seq Scan on run_values
    ->  Custom Scan (RuntimeAppend)
-         Prune by: (run_values.val = t1.id)
+         Prune by: (t1.id = run_values.val)
          ->  Index Only Scan using runtime_test_1_0_pkey on runtime_test_1_0 t1
                Index Cond: (id = run_values.val)
          ->  Index Only Scan using runtime_test_1_1_pkey on runtime_test_1_1 t1
```

I'm only assuming that the commit a5fc46414deb7cbcd4cec1275efac69b9ac10500 (Avoid making
commutatively-duplicate clauses in EquivalenceClasses.) caused these changes.