### PR TITLE
PGPRO-8238, PGPRO-8122: Fix build with master at 5df319f3d. Corrected number of args in some functions.

### DIFF
--- a/src/include/compat/pg_compat.h
+++ b/src/include/compat/pg_compat.h
@@ -779,7 +779,12 @@ extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 /*
  * ExecBRUpdateTriggers()
  */
-#if PG_VERSION_NUM >= 150000 /* for commit 7103ebb7aae8 */
+#if PG_VERSION_NUM >= 160000
+#define ExecBRUpdateTriggersCompat(estate, epqstate, relinfo, \
+					 tupleid, fdw_trigtuple, newslot) \
+	ExecBRUpdateTriggers((estate), (epqstate), (relinfo), (tupleid), \
+						 (fdw_trigtuple), (newslot), NULL, NULL)
+#elif PG_VERSION_NUM >= 150000 /* for commit 7103ebb7aae8 */
 #define ExecBRUpdateTriggersCompat(estate, epqstate, relinfo, \
 					 tupleid, fdw_trigtuple, newslot) \
 	ExecBRUpdateTriggers((estate), (epqstate), (relinfo), (tupleid), \
@@ -809,7 +814,12 @@ extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 /*
  * ExecBRDeleteTriggers()
  */
-#if PG_VERSION_NUM >= 110000
+#if PG_VERSION_NUM >= 160000
+#define ExecBRDeleteTriggersCompat(estate, epqstate, relinfo, tupleid, \
+								   fdw_trigtuple, epqslot) \
+	ExecBRDeleteTriggers((estate), (epqstate), (relinfo), (tupleid), \
+						 (fdw_trigtuple), (epqslot), NULL, NULL)
+#elif PG_VERSION_NUM >= 110000
 #define ExecBRDeleteTriggersCompat(estate, epqstate, relinfo, tupleid, \
 								   fdw_trigtuple, epqslot) \
 	ExecBRDeleteTriggers((estate), (epqstate), (relinfo), (tupleid), \
@@ -1028,15 +1038,19 @@ extern AttrNumber *convert_tuples_by_name_map(TupleDesc indesc,
 /*
  * ExecInsertIndexTuples. Since 12 slot contains tupleid.
  * Since 14: new fields "resultRelInfo", "update".
+ * Since 16: new bool field "onlySummarizing".
  */
-#if PG_VERSION_NUM >= 140000
-#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes) \
+#if PG_VERSION_NUM >= 160000
+#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes, onlySummarizing) \
+	ExecInsertIndexTuples((resultRelInfo), (slot), (estate), (update), (noDupError), (specConflict), (arbiterIndexes), (onlySummarizing))
+#elif PG_VERSION_NUM >= 140000
+#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes, onlySummarizing) \
 	ExecInsertIndexTuples((resultRelInfo), (slot), (estate), (update), (noDupError), (specConflict), (arbiterIndexes))
 #elif PG_VERSION_NUM >= 120000
-#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes) \
+#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes, onlySummarizing) \
 	ExecInsertIndexTuples((slot), (estate), (noDupError), (specConflict), (arbiterIndexes))
 #else
-#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes) \
+#define ExecInsertIndexTuplesCompat(resultRelInfo, slot, tupleid, estate, update, noDupError, specConflict, arbiterIndexes, onlySummarizing) \
 	ExecInsertIndexTuples((slot), (tupleid), (estate), (noDupError), (specConflict), (arbiterIndexes))
 #endif
 

--- a/src/utility_stmt_hooking.c
+++ b/src/utility_stmt_hooking.c
@@ -564,10 +564,14 @@ PathmanCopyFrom(
 
 #if PG_VERSION_NUM >= 140000  /* reworked in 1375422c7826 */
 	/*
-	 * Call ExecInitRangeTable() should be first because in 14 it initializes
+	 * Call ExecInitRangeTable() should be first because in 14+ it initializes
 	 * field "estate->es_result_relations":
 	 */
+#if PG_VERSION_NUM >= 160000
+	ExecInitRangeTable(estate, range_table, cstate->rteperminfos);
+#else
 	ExecInitRangeTable(estate, range_table);
+#endif
 	estate->es_result_relations =
 		(ResultRelInfo **) palloc0(list_length(range_table) * sizeof(ResultRelInfo *));
 	estate->es_result_relations[0] = parent_rri;
@@ -749,7 +753,7 @@ PathmanCopyFrom(
 				/* ... and create index entries for it */
 				if (child_rri->ri_NumIndices > 0)
 					recheckIndexes = ExecInsertIndexTuplesCompat(estate->es_result_relation_info,
-										slot, &(tuple->t_self), estate, false, false, NULL, NIL);
+										slot, &(tuple->t_self), estate, false, false, NULL, NIL, false);
 			}
 #ifdef PG_SHARDMAN
 			/* Handle foreign tables */


### PR DESCRIPTION
Correct number of args in ExecInitRangeTable(), ExecInsertIndexTuples(), ExecBRUpdateTriggers() and ExecBRDeleteTriggers().

Caused by:
- b803b7d132e3505ab77c29acf91f3d1caa298f95 Fill EState.es_rteperminfos more systematically.
- 19d8e2308bc51ec4ab993ce90077342c915dd116 Ignore BRIN indexes when checking for HOT updates
- 9321c79c86e6a6a4eac22e2235a21a8b68388723 Fix concurrent update issues with MERGE. Tags: pg_pathman