### PR TITLE
[PGPRO-16769] Fix Travis CI failures

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -9,10 +9,11 @@ RUN apk add --no-cache \
 	coreutils linux-headers \
 	make musl-dev gcc bison flex \
 	zlib-dev libedit-dev \
-	pkgconf icu-dev clang clang15 clang-analyzer;
+	pkgconf icu-dev clang clang-analyzer;
 
 # Need this for Travis CI to pass
 RUN if [ "${PG_VERSION}" == "13" ] ; then apk add --no-cache clang19; fi
+RUN if [ "${PG_VERSION}" == "11" ] ; then apk add --no-cache clang15; fi
 
 # Install fresh valgrind
 RUN apk add valgrind \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -108,7 +108,11 @@ if [ "$LEVEL" = "scan-build" ] || \
    [ "$LEVEL" = "nightmare" ]; then
 
 	# perform static analyzis
-	scan-build --status-bugs make USE_PGXS=1 || status=$?
+	if [ "${PG_VERSION%.*}" = "11" ]; then
+		scan-build --status-bugs make USE_PGXS=1 CLANG=clang-15 || status=$?
+	else
+		scan-build --status-bugs make USE_PGXS=1 CLANG=clang || status=$?
+	fi
 
 	# something's wrong, exit now!
 	if [ $status -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
Two issues were causing Travis CI failures:

1. Alpine Linux removed clang15 from its package repositories in recent
    versions. Fixed by removing clang15 from Dockerfile dependencies for
    PostgreSQL versions above 11.

2. scan-build with clang-21 fails when analyzing PostgreSQL extensions
   built via PGXS. The issue occurs because:

   - scan-build sets CLANG environment variable to the analyzer path
   - PGXS resets CLANG to an empty string
   - ccc-analyzer v21 does not check the CLANG variable for an empty string
   - This causes ccc-analyzer to attempt executing an empty command string

   Fixed by explicitly passing CLANG as a make command-line argument.

Tags: pg_pathman